### PR TITLE
Prevent an user to list the members of a group if the user isn't an a…

### DIFF
--- a/src/main/java/dwbh/api/domain/input/UserGroupInput.java
+++ b/src/main/java/dwbh/api/domain/input/UserGroupInput.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 public class UserGroupInput {
   private final UUID userId;
   private final UUID groupId;
+  private final boolean visibleMemberList;
 
   /**
    * Returns the id of the user
@@ -49,7 +50,17 @@ public class UserGroupInput {
   }
 
   /**
-   * Initializes the input with the group's name, visibleMemberList and anonymousVote
+   * Returns if the group has a visible member list
+   *
+   * @return if the group has a visible member list
+   * @since 0.1.0
+   */
+  public boolean isVisibleMemberList() {
+    return visibleMemberList;
+  }
+
+  /**
+   * Initializes the input with the user id and the group id
    *
    * @param userId the id of the user
    * @param groupId the id of the group
@@ -58,5 +69,20 @@ public class UserGroupInput {
   public UserGroupInput(UUID userId, UUID groupId) {
     this.userId = userId;
     this.groupId = groupId;
+    this.visibleMemberList = false;
+  }
+
+  /**
+   * Initializes the input with the user id, the group id, and visibleMemberList
+   *
+   * @param userId the id of the user
+   * @param groupId the id of the group
+   * @param visibleMemberList if the group has visible member list
+   * @since 0.1.0
+   */
+  public UserGroupInput(UUID userId, UUID groupId, boolean visibleMemberList) {
+    this.userId = userId;
+    this.groupId = groupId;
+    this.visibleMemberList = visibleMemberList;
   }
 }

--- a/src/main/java/dwbh/api/fetchers/GroupFetcherUtils.java
+++ b/src/main/java/dwbh/api/fetchers/GroupFetcherUtils.java
@@ -18,12 +18,10 @@
 package dwbh.api.fetchers;
 
 import dwbh.api.domain.input.GroupInput;
-import dwbh.api.domain.input.UserGroupInput;
 import graphql.schema.DataFetchingEnvironment;
 import java.time.DayOfWeek;
 import java.time.OffsetTime;
 import java.util.List;
-import java.util.UUID;
 
 /**
  * Contains functions to build domain inputs from the underlying {@link DataFetchingEnvironment}
@@ -53,19 +51,5 @@ final class GroupFetcherUtils {
     OffsetTime votingTime = environment.getArgument("votingTime");
 
     return new GroupInput(name, visibleMemberList, anonymousVote, votingDays, votingTime);
-  }
-
-  /**
-   * Creates a {@link UserGroupInput} from the data coming from the {@link DataFetchingEnvironment}
-   *
-   * @param environment the GraphQL {@link DataFetchingEnvironment}
-   * @return an instance of {@link UserGroupInput}
-   * @since 0.1.0
-   */
-  /* default */ static UserGroupInput userGroup(DataFetchingEnvironment environment) {
-    UUID userId = environment.getArgument("userId");
-    UUID groupId = environment.getArgument("groupId");
-
-    return new UserGroupInput(userId, groupId);
   }
 }

--- a/src/main/java/dwbh/api/fetchers/UserFetcher.java
+++ b/src/main/java/dwbh/api/fetchers/UserFetcher.java
@@ -17,7 +17,6 @@
  */
 package dwbh.api.fetchers;
 
-import dwbh.api.domain.Group;
 import dwbh.api.domain.User;
 import dwbh.api.services.UserService;
 import graphql.schema.DataFetchingEnvironment;
@@ -71,17 +70,5 @@ public class UserFetcher {
   public User getUser(DataFetchingEnvironment env) {
     UUID userId = env.getArgument("id");
     return service.getUser(userId);
-  }
-
-  /**
-   * Fetches the users that belongs to a group
-   *
-   * @param env GraphQL execution environment
-   * @return a list of available {@link User}
-   * @since 0.1.0
-   */
-  public List<User> listUsersGroup(DataFetchingEnvironment env) {
-    Group group = env.getSource();
-    return service.listUsersGroup(group.getId());
   }
 }

--- a/src/main/java/dwbh/api/fetchers/UserGroupFetcher.java
+++ b/src/main/java/dwbh/api/fetchers/UserGroupFetcher.java
@@ -27,6 +27,7 @@ import dwbh.api.services.UserGroupService;
 import dwbh.api.util.Result;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
 import javax.inject.Singleton;
 
 /**
@@ -63,7 +64,7 @@ public class UserGroupFetcher {
    */
   public DataFetcherResult<Boolean> addUserToGroup(DataFetchingEnvironment env) {
     Context ctx = env.getContext();
-    UserGroupInput input = GroupFetcherUtils.userGroup(env);
+    UserGroupInput input = UserGroupFetcherUtils.userGroupInput(env);
     User user = ctx.getAuthenticatedUser();
 
     Result<Boolean> result = service.addUserToGroup(user, input);
@@ -82,5 +83,17 @@ public class UserGroupFetcher {
     User user = ctx.getAuthenticatedUser();
     Group group = env.getSource();
     return service.isAdmin(user, group);
+  }
+
+  /**
+   * Fetches the users that belongs to a group
+   *
+   * @param env GraphQL execution environment
+   * @return a list of available {@link User}
+   * @since 0.1.0
+   */
+  public List<User> listUsersGroup(DataFetchingEnvironment env) {
+    UserGroupInput input = UserGroupFetcherUtils.userGroupAndVisibleMembersInput(env);
+    return service.listUsersGroup(input);
   }
 }

--- a/src/main/java/dwbh/api/fetchers/UserGroupFetcherUtils.java
+++ b/src/main/java/dwbh/api/fetchers/UserGroupFetcherUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.fetchers;
+
+import dwbh.api.domain.Group;
+import dwbh.api.domain.User;
+import dwbh.api.domain.input.UserGroupInput;
+import dwbh.api.graphql.Context;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.UUID;
+
+/**
+ * Contains functions to build domain inputs from the underlying {@link DataFetchingEnvironment}
+ * coming from the GraphQL engine execution. This class is meant to be used only for the {@link
+ * UserGroupFetcher} instance and related tests.
+ *
+ * @since 0.1.0
+ */
+final class UserGroupFetcherUtils {
+
+  private UserGroupFetcherUtils() {
+    /* empty */
+  }
+
+  private static User getCurrentUser(DataFetchingEnvironment environment) {
+    Context ctx = environment.getContext();
+    return ctx.getAuthenticatedUser();
+  }
+
+  /**
+   * Creates a {@link UserGroupInput} from the data coming from the {@link DataFetchingEnvironment}
+   *
+   * @param environment the GraphQL {@link DataFetchingEnvironment}
+   * @return an instance of {@link UserGroupInput}
+   * @since 0.1.0
+   */
+  /* default */ static UserGroupInput userGroupAndVisibleMembersInput(
+      DataFetchingEnvironment environment) {
+    User currentUser = getCurrentUser(environment);
+    Group group = environment.getSource();
+    return new UserGroupInput(currentUser.getId(), group.getId(), group.isVisibleMemberList());
+  }
+
+  /**
+   * Creates a {@link UserGroupInput} from the data coming from the {@link DataFetchingEnvironment}
+   *
+   * @param environment the GraphQL {@link DataFetchingEnvironment}
+   * @return an instance of {@link UserGroupInput}
+   * @since 0.1.0
+   */
+  /* default */ static UserGroupInput userGroupInput(DataFetchingEnvironment environment) {
+    UUID userId = environment.getArgument("userId");
+    UUID groupId = environment.getArgument("groupId");
+
+    return new UserGroupInput(userId, groupId);
+  }
+}

--- a/src/main/java/dwbh/api/graphql/GraphQLFactory.java
+++ b/src/main/java/dwbh/api/graphql/GraphQLFactory.java
@@ -127,9 +127,11 @@ public class GraphQLFactory {
                 "Group",
                 builder ->
                     builder
-                        .dataFetcher("members", userFetcher::listUsersGroup)
+                        .dataFetcher("members", userGroupFetcher::listUsersGroup)
                         .dataFetcher("isCurrentUserAdmin", userGroupFetcher::isCurrentUserAdmin))
-            .type("User", builder -> builder.dataFetcher("groups", groupFetcher::listGroupsUser))
+            .type(
+                "UserProfile",
+                builder -> builder.dataFetcher("groups", groupFetcher::listGroupsUser))
             .build();
 
     return new SchemaGenerator().makeExecutableSchema(registry, wiring);

--- a/src/main/java/dwbh/api/services/UserService.java
+++ b/src/main/java/dwbh/api/services/UserService.java
@@ -18,7 +18,6 @@
 package dwbh.api.services;
 
 import dwbh.api.domain.User;
-import dwbh.api.repositories.UserGroupRepository;
 import dwbh.api.repositories.UserRepository;
 import java.util.List;
 import java.util.UUID;
@@ -33,18 +32,15 @@ import javax.inject.Singleton;
 public class UserService {
 
   private final transient UserRepository userRepository;
-  private final transient UserGroupRepository userGroupRepository;
 
   /**
    * Initializes service by using the database repository
    *
    * @param userRepository an instance of {@link UserRepository}
-   * @param userGroupRepository an instance of {@link UserGroupRepository}
    * @since 0.1.0
    */
-  public UserService(UserRepository userRepository, UserGroupRepository userGroupRepository) {
+  public UserService(UserRepository userRepository) {
     this.userRepository = userRepository;
-    this.userGroupRepository = userGroupRepository;
   }
 
   /**
@@ -66,16 +62,5 @@ public class UserService {
    */
   public User getUser(UUID id) {
     return userRepository.getUser(id);
-  }
-
-  /**
-   * Fetches the list of users in a Group
-   *
-   * @param groupId group identifier
-   * @return a list of {@link User} instances
-   * @since 0.1.0
-   */
-  public List<User> listUsersGroup(UUID groupId) {
-    return userGroupRepository.listUsersGroup(groupId);
   }
 }

--- a/src/main/java/dwbh/api/util/ErrorConstants.java
+++ b/src/main/java/dwbh/api/util/ErrorConstants.java
@@ -66,6 +66,13 @@ public final class ErrorConstants {
       new Error("API_ERRORS.USER_NOT_IN_GROUP", "The user doesn't belong to group");
 
   /**
+   * Generic code used when somebody is not allowed to do something
+   *
+   * @since 0.1.0
+   */
+  public static final Error NOT_ALLOWED = new Error("API_ERRORS.NOT_ALLOWED", "Not allowed");
+
+  /**
    * Code used when somebody not belonging to a group tries to execute some operation over that
    * group
    *

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -34,11 +34,16 @@ type Group {
     isCurrentUserAdmin: Boolean
 }
 
-type User {
+type UserProfile {
     id: ID
     name: String
     email: String
     groups: [Group]
+}
+
+type User {
+    id: ID
+    name: String
 }
 
 type Voting {
@@ -65,14 +70,8 @@ type Login {
 
 # registered queries
 type Query {
-    # get full group list
-    listGroups: [Group]
-
     # get groups of the current user
     listMyGroups: [Group]
-
-    # get full user list
-    listUsers: [User]
 
     # get group by its id
     getGroup(id: ID!): Group

--- a/src/test/java/dwbh/api/fetchers/UserFetcherTest.java
+++ b/src/test/java/dwbh/api/fetchers/UserFetcherTest.java
@@ -22,11 +22,9 @@ import static io.github.benas.randombeans.api.EnhancedRandom.randomListOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import dwbh.api.domain.Group;
 import dwbh.api.domain.User;
 import dwbh.api.fetchers.utils.FetcherTestUtils;
 import dwbh.api.services.UserService;
-import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -75,31 +73,5 @@ class UserFetcherTest {
 
     // then: check certain assertions should be met
     assertThat("the user is found", result, is(user));
-  }
-
-  @Test
-  void testListUsersGroup() {
-    // given: a group
-    Group group = random(Group.class);
-
-    // and: a mocked service
-    var mockedService = Mockito.mock(UserService.class);
-
-    // and: a mocked environment
-    var mockedEnvironment = Mockito.mock(DataFetchingEnvironment.class);
-
-    // and: mocking service's behavior
-    Mockito.when(mockedService.listUsersGroup(group.getId()))
-        .thenReturn(randomListOf(2, User.class));
-
-    // and: mocking environment behavior
-    Mockito.when(mockedEnvironment.getSource()).thenReturn(group);
-
-    // when: fetching user list invoking the service
-    UserFetcher fetchers = new UserFetcher(mockedService);
-    List<User> userList = fetchers.listUsersGroup(mockedEnvironment);
-
-    // then: check certain assertions should be met
-    assertThat("there're only a certain number of users", userList.size(), is(2));
   }
 }

--- a/src/test/java/dwbh/api/fetchers/UserGroupFetcherTest.java
+++ b/src/test/java/dwbh/api/fetchers/UserGroupFetcherTest.java
@@ -18,6 +18,9 @@
 package dwbh.api.fetchers;
 
 import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static io.github.benas.randombeans.api.EnhancedRandom.randomListOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -30,6 +33,7 @@ import dwbh.api.fetchers.utils.FetcherTestUtils;
 import dwbh.api.graphql.I18nGraphQLError;
 import dwbh.api.services.UserGroupService;
 import dwbh.api.util.Result;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -130,5 +134,33 @@ class UserGroupFetcherTest {
 
     // then: there result is true
     assertTrue(result);
+  }
+
+  @Test
+  void testListUsersGroup() {
+    // given: a group
+    Group group = random(Group.class);
+
+    // and: an user
+    User user = random(User.class);
+
+    // and: a mocked service
+    var mockedService = Mockito.mock(UserGroupService.class);
+
+    // and: a mocked environment
+    var mockedEnvironment = FetcherTestUtils.generateMockedEnvironment(user, Map.of());
+
+    // and: mocking service's behavior
+    Mockito.when(mockedService.listUsersGroup(any())).thenReturn(randomListOf(2, User.class));
+
+    // and: mocking environment behavior
+    Mockito.when(mockedEnvironment.getSource()).thenReturn(group);
+
+    // when: fetching user list invoking the service
+    UserGroupFetcher fetchers = new UserGroupFetcher(mockedService);
+    List<User> userList = fetchers.listUsersGroup(mockedEnvironment);
+
+    // then: check certain assertions should be met
+    assertThat("there're only a certain number of users", userList.size(), is(2));
   }
 }

--- a/src/test/java/dwbh/api/graphql/GraphQLFactoryTest.java
+++ b/src/test/java/dwbh/api/graphql/GraphQLFactoryTest.java
@@ -47,7 +47,7 @@ class GraphQLFactoryTest {
 
     // and: mocking group fetcher behavior
     var groupFetcher = mock(GroupFetcher.class);
-    when(groupFetcher.listGroups(any())).thenReturn(randomListOf(2, Group.class));
+    when(groupFetcher.listMyGroups(any())).thenReturn(randomListOf(2, Group.class));
 
     // and: adding group fetcher to fetcher providers
     fetchers.setGroupFetcher(groupFetcher);
@@ -73,13 +73,13 @@ class GraphQLFactoryTest {
     context.setAuthenticatedUser(new User());
     var executionInput =
         ExecutionInput.newExecutionInput()
-            .query("{ listGroups { name } }")
+            .query("{ listMyGroups { name } }")
             .context(context)
             .build();
     var result = graphQLEngine.execute(executionInput);
     Map<String, List<Map<String, ?>>> data = result.getData();
 
-    var groupList = data.get("listGroups");
+    var groupList = data.get("listMyGroups");
 
     // then: we should get the expected result
     assertEquals(groupList.size(), 2);

--- a/src/test/java/dwbh/api/services/UserServiceTests.java
+++ b/src/test/java/dwbh/api/services/UserServiceTests.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 
 import dwbh.api.domain.User;
-import dwbh.api.repositories.UserGroupRepository;
 import dwbh.api.repositories.UserRepository;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -44,7 +43,7 @@ public class UserServiceTests {
     Mockito.when(userRepository.listUsers()).thenReturn(randomListOf(4, User.class));
 
     // when: invoking service listUsers()
-    var userService = new UserService(userRepository, null);
+    var userService = new UserService(userRepository);
     var userList = userService.listUsers();
 
     // then: we should get the expected number of users
@@ -58,24 +57,10 @@ public class UserServiceTests {
     Mockito.when(userRepository.getUser(any())).thenReturn(random(User.class));
 
     // when: getting a user by id
-    var userService = new UserService(userRepository, null);
+    var userService = new UserService(userRepository);
     var user = userService.getUser(UUID.randomUUID());
 
     // then: we should get it
     assertNotNull(user);
-  }
-
-  @Test
-  void testListUsersGroup() {
-    // given: a mocked user repository
-    var userGroupRepository = Mockito.mock(UserGroupRepository.class);
-    Mockito.when(userGroupRepository.listUsersGroup(any())).thenReturn(randomListOf(5, User.class));
-
-    // when: getting a list of users by group
-    var userService = new UserService(null, userGroupRepository);
-    var usersByGroup = userService.listUsersGroup(UUID.randomUUID());
-
-    // then: we should get the expected number of users
-    assertEquals(5, usersByGroup.size());
   }
 }


### PR DESCRIPTION
![](https://media2.giphy.com/media/l0HlRm6qktwMWXnyw/giphy.gif?cid=3640f6095c9268d54c764e5063955ade)
## How to test
* Make an api call to MyGroups with the user tstark, asking for the members of his groups. The user can't list the members of the groups with "visibleMemberList": false, where he isn't an admin

```
query{
  listMyGroups{
    id
    name
    isCurrentUserAdmin
    visibleMemberList    
    members {
      name
    }
  }
}
```

* Change on database the visibleMemberList value of his groups. Check that now he can access the members list