### PR TITLE
Add changes to createdAt field

### DIFF
--- a/src/main/java/dwbh/api/domain/Vote.java
+++ b/src/main/java/dwbh/api/domain/Vote.java
@@ -30,7 +30,7 @@ public final class Vote {
   private transient UUID id;
   private transient Voting voting;
   private transient User createdBy;
-  private transient OffsetDateTime createdAt;
+  private transient OffsetDateTime createdAtDateTime;
   private transient String comment;
   private transient Integer score;
 
@@ -114,18 +114,18 @@ public final class Vote {
    * @return an instance of type {@link OffsetDateTime}
    * @since 0.1.0
    */
-  public OffsetDateTime getCreatedAt() {
-    return createdAt;
+  public OffsetDateTime getCreatedAtDateTime() {
+    return createdAtDateTime;
   }
 
   /**
    * Sets when the vote has been created
    *
-   * @param createdAt when the vote's been created
+   * @param createdAtDateTime when the vote's been created
    * @since 0.1.0
    */
-  public void setCreatedAt(OffsetDateTime createdAt) {
-    this.createdAt = createdAt;
+  public void setCreatedAtDateTime(OffsetDateTime createdAtDateTime) {
+    this.createdAtDateTime = createdAtDateTime;
   }
 
   /**

--- a/src/main/java/dwbh/api/domain/Voting.java
+++ b/src/main/java/dwbh/api/domain/Voting.java
@@ -28,7 +28,7 @@ import java.util.UUID;
  */
 public final class Voting {
   private UUID id;
-  private OffsetDateTime createdAt;
+  private OffsetDateTime createdAtDateTime;
   private User createdBy;
   private Group group;
   private Integer average;
@@ -73,18 +73,18 @@ public final class Voting {
    * @return the moment the voting was created
    * @since 0.1.0
    */
-  public OffsetDateTime getCreatedAt() {
-    return createdAt;
+  public OffsetDateTime getCreatedAtDateTime() {
+    return createdAtDateTime;
   }
 
   /**
    * Sets the moment the voting was created
    *
-   * @param createdAt when the voting was created
+   * @param createdAtDateTime when the voting was created
    * @since 0.1.0
    */
-  public void setCreatedAt(OffsetDateTime createdAt) {
-    this.createdAt = createdAt;
+  public void setCreatedAtDateTime(OffsetDateTime createdAtDateTime) {
+    this.createdAtDateTime = createdAtDateTime;
   }
 
   /**

--- a/src/main/java/dwbh/api/repositories/internal/JooqVotingRepository.java
+++ b/src/main/java/dwbh/api/repositories/internal/JooqVotingRepository.java
@@ -234,7 +234,7 @@ public class JooqVotingRepository implements VotingRepository {
   private static Voting toVoting(Record record) {
     return Voting.newBuilder()
         .with(voting -> voting.setId(record.get(VotingTableHelper.VOTING_ID)))
-        .with(voting -> voting.setCreatedAt(record.get(VotingTableHelper.CREATED_AT)))
+        .with(voting -> voting.setCreatedAtDateTime(record.get(VotingTableHelper.CREATED_AT)))
         .with(voting -> voting.setAverage(record.get(VotingTableHelper.AVERAGE)))
         .build();
   }
@@ -242,7 +242,7 @@ public class JooqVotingRepository implements VotingRepository {
   private static Vote toVote(Record record) {
     return Vote.newBuilder()
         .with(vote -> vote.setId(record.get(VoteTableHelper.VOTE_ID)))
-        .with(vote -> vote.setCreatedAt(record.get(VoteTableHelper.CREATED_AT)))
+        .with(vote -> vote.setCreatedAtDateTime(record.get(VoteTableHelper.CREATED_AT)))
         .with(vote -> vote.setComment(record.get(VoteTableHelper.COMMENT)))
         .with(vote -> vote.setScore(record.get(VoteTableHelper.SCORE)))
         .build();

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -50,7 +50,7 @@ type User {
 type Voting {
     id: ID,
     group: Group,
-    createdAt: DateTime
+    createdAtDateTime: DateTime
     createdBy: User
     average: Int
     votes: [Vote]
@@ -61,7 +61,7 @@ type Vote {
     score: Int
     comment: String
     voting: Voting
-    createdAt: DateTime
+    createdAtDateTime: DateTime
     createdBy: User
 }
 


### PR DESCRIPTION
There's a convention with the front end about providing correct formatting to Date and DateTime types of values. The convention is just naming fields according to type, adding correspondent `DateTime` or `Time` suffix to time field names.