### PR TITLE
Add the day of the week and internationalize dates in emails. 

### DIFF
--- a/etc/pmd/rulesets-general.xml
+++ b/etc/pmd/rulesets-general.xml
@@ -67,6 +67,7 @@
         <exclude name="DataClass"/>
         <exclude name="LawOfDemeter"/>
         <exclude name="LoosePackageCoupling"/>
+        <exclude name="ExcessiveImports"/>
     </rule>
 
     <rule ref="category/java/documentation.xml"/>

--- a/src/test/java/dwbh/api/services/internal/VotingSchedulingServiceTests.java
+++ b/src/test/java/dwbh/api/services/internal/VotingSchedulingServiceTests.java
@@ -34,13 +34,17 @@ import dwbh.api.services.internal.templates.JadeTemplateService;
 import dwbh.api.services.internal.templates.URLResolverService;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class VotingSchedulingServiceTests {
+
+  private static final Locale LOCALE = new Locale("es", "ES");
 
   @Test
   void testNotifyNewVotingToMembers() {
@@ -50,7 +54,7 @@ public class VotingSchedulingServiceTests {
     var votingRepository = Mockito.mock(VotingRepository.class);
     var emailService = Mockito.mock(EmailService.class);
     var templateService = Mockito.mock(JadeTemplateService.class);
-    var resourceBundle = ResourceBundle.getBundle("messages");
+    var resourceBundle = ResourceBundle.getBundle("messages", LOCALE);
     var urlResolverService = Mockito.mock(URLResolverService.class);
 
     // and: mocking behaviors
@@ -76,7 +80,8 @@ public class VotingSchedulingServiceTests {
             emailService,
             templateService,
             resourceBundle,
-            urlResolverService);
+            urlResolverService,
+            Optional.of("es"));
 
     // when: executing scheduling task
     schedulingService.scheduleVoting();


### PR DESCRIPTION
Fixes #60. Fixes #61.

<h3>Validation Tests</h3>

1. Check the subject of the email executing this test

> ./gradlew test --tests VotingSchedulingServiceTests

adding a log showing the email subject in "VotingSchedulingService::createEmail"

>    String body = jadeTemplateService.render(template, model);
>    LOG.info(String.format(String.format("Email subject: %s", subject)));

Verify the standard output of the test, to check the name of the week appears, and the date is 29/4/20 (spanish), and not 4/29/20.

2. Then change the locale in the test to english to verify it changes properly in a second execution:

>  public class VotingSchedulingServiceTests {
>    
>    private final static Locale LOCALE = new Locale("en","EN");
>    ...
>         new VotingSchedulingService(
>             ...
>             Optional.of("en"));
> 