### PR TITLE
Task/22/reset password request

### DIFF
--- a/src/main/java/dwbh/api/graphql/GraphQLFactory.java
+++ b/src/main/java/dwbh/api/graphql/GraphQLFactory.java
@@ -96,6 +96,7 @@ public class GraphQLFactory {
       TypeDefinitionRegistry registry, FetcherProvider fetcherProvider) {
     var groupFetcher = fetcherProvider.getGroupFetcher();
     var userFetcher = fetcherProvider.getUserFetcher();
+    var resetPasswordFetcher = fetcherProvider.getResetPasswordFetcher();
     var userGroupFetcher = fetcherProvider.getUserGroupFetcher();
     var securityFetcher = fetcherProvider.getSecurityFetcher();
     var votingFetcher = fetcherProvider.getVotingFetcher();
@@ -128,6 +129,7 @@ public class GraphQLFactory {
                         .dataFetcher("createGroup", groupFetcher::createGroup)
                         .dataFetcher("updateGroup", groupFetcher::updateGroup)
                         .dataFetcher("addUserToGroup", userGroupFetcher::addUserToGroup)
+                        .dataFetcher("resetPassword", resetPasswordFetcher::resetPassword)
                         .dataFetcher("createVoting", votingFetcher::createVoting)
                         .dataFetcher("createVote", votingFetcher::createVote)
                         .dataFetcher("leaveGroup", userGroupFetcher::leaveGroup))

--- a/src/main/java/dwbh/api/graphql/fetchers/FetcherProvider.java
+++ b/src/main/java/dwbh/api/graphql/fetchers/FetcherProvider.java
@@ -35,6 +35,7 @@ public class FetcherProvider {
   private GroupFetcher groupFetcher;
   private VotingFetcher votingFetcher;
   private UserFetcher userFetcher;
+  private ResetPasswordFetcher resetPasswordFetcher;
   private UserGroupFetcher userGroupFetcher;
   private SecurityFetcher securityFetcher;
 
@@ -141,5 +142,26 @@ public class FetcherProvider {
   @Inject
   public void setSecurityFetcher(SecurityFetcher securityFetcher) {
     this.securityFetcher = securityFetcher;
+  }
+
+  /**
+   * Returns an instance of {@link ResetPasswordFetcher}
+   *
+   * @return an instance of {@link ResetPasswordFetcher}
+   * @since 0.1.0
+   */
+  public ResetPasswordFetcher getResetPasswordFetcher() {
+    return resetPasswordFetcher;
+  }
+
+  /**
+   * Sets the instance responsible to handle user password requests
+   *
+   * @param resetPasswordFetcher instance of {@link ResetPasswordFetcher}
+   * @since 0.1.0
+   */
+  @Inject
+  public void setResetPasswordFetcher(ResetPasswordFetcher resetPasswordFetcher) {
+    this.resetPasswordFetcher = resetPasswordFetcher;
   }
 }

--- a/src/main/java/dwbh/api/graphql/fetchers/ResetPasswordFetcher.java
+++ b/src/main/java/dwbh/api/graphql/fetchers/ResetPasswordFetcher.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.graphql.fetchers;
+
+import dwbh.api.domain.User;
+import dwbh.api.services.ResetPasswordService;
+import dwbh.api.services.internal.DefaultUserService;
+import graphql.schema.DataFetchingEnvironment;
+import javax.inject.Singleton;
+
+/**
+ * All related GraphQL operations over the {@link User} password
+ *
+ * @since 0.1.0
+ */
+@Singleton
+public class ResetPasswordFetcher {
+
+  /**
+   * Instance handling the business logic
+   *
+   * @since 0.1.0
+   */
+  private final transient ResetPasswordService service;
+
+  /**
+   * Constructor initializing the access to the business logic
+   *
+   * @param service instance of {@link DefaultUserService}
+   * @since 0.1.0
+   */
+  public ResetPasswordFetcher(ResetPasswordService service) {
+    this.service = service;
+  }
+
+  /**
+   * Initiates the process of resetting the password for a user
+   *
+   * @param env GraphQL execution environment
+   * @return true
+   */
+  public Boolean resetPassword(DataFetchingEnvironment env) {
+    String email = env.getArgument("email");
+    service.resetPasswordRequest(email);
+    return true;
+  }
+}

--- a/src/main/java/dwbh/api/services/EmailComposer.java
+++ b/src/main/java/dwbh/api/services/EmailComposer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.services;
+
+import dwbh.api.domain.Email;
+import java.util.Map;
+
+/**
+ * Different methods and utilities regarding the composition of emails
+ *
+ * @since 0.1.0
+ */
+public interface EmailComposer {
+
+  /**
+   * Compose an {@link Email} from its different parts
+   *
+   * @param recipient the email recipient (jsmith@example.com)
+   * @param subject the email subject
+   * @param bodyTemplate the path where the html body template is located (with the html email body)
+   * @param bodyVariables the Map of variables the bodyTemplate requires to be interpolated with
+   * @return the composed {@link Email}
+   */
+  Email composeEmail(
+      String recipient, String subject, String bodyTemplate, Map<String, Object> bodyVariables);
+
+  /**
+   * Get a text message from a messages.properties file
+   *
+   * @param key the key to which recover the text from
+   * @param variables the variables in the text that should be interpolated
+   * @return the text message
+   */
+  String getMessage(String key, Map<String, Object> variables);
+
+  /**
+   * Get a plain text message, no variables to interpolate, from a messages.properties file
+   *
+   * @param key the key to which recover the text from
+   * @return the text message
+   */
+  String getMessage(String key);
+
+  /**
+   * Get a composed message representing the current date
+   *
+   * @return the textual date
+   */
+  String getTodayMessage();
+}

--- a/src/main/java/dwbh/api/services/ResetPasswordService.java
+++ b/src/main/java/dwbh/api/services/ResetPasswordService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.services;
+
+/**
+ * Business logic to handle user password operations
+ *
+ * @since 0.1.0
+ */
+public interface ResetPasswordService {
+
+  /**
+   * Sends an userEmail to the user with a generated OTP link to reset her previous password
+   *
+   * @param userEmail user userEmail
+   */
+  void resetPasswordRequest(String userEmail);
+}

--- a/src/main/java/dwbh/api/services/internal/DefaultResetPasswordService.java
+++ b/src/main/java/dwbh/api/services/internal/DefaultResetPasswordService.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.services.internal;
+
+import dwbh.api.domain.Email;
+import dwbh.api.domain.User;
+import dwbh.api.repositories.UserRepository;
+import dwbh.api.services.EmailService;
+import dwbh.api.services.ResetPasswordService;
+import dwbh.api.services.internal.templates.URLResolverService;
+import io.micronaut.context.annotation.Value;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import javax.inject.Singleton;
+import javax.transaction.Transactional;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Business logic to handle user password operations
+ *
+ * @since 0.1.0
+ */
+@Singleton
+@Transactional
+public class DefaultResetPasswordService implements ResetPasswordService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultResetPasswordService.class);
+
+  private final transient String resetPasswordUrl;
+  private final transient UserRepository userRepository;
+  private final transient Auth0CryptoService cryptoService;
+  private final transient EmailComposerService emailComposerService;
+  private final transient EmailService emailService;
+  private final transient URLResolverService urlResolverService;
+
+  /**
+   * Initializes service by using the required services
+   *
+   * @param resetPasswordUrl to get the link from configuration
+   * @param userRepository an instance of {@link UserRepository}
+   * @param auth0CryptoService an instance of {@link Auth0CryptoService}
+   * @param emailComposerService service to compose the {@link Email} notifications
+   * @param emailService to be able to send notifications to group members
+   * @param urlResolverService to resolve possible link urls for emails
+   */
+  public DefaultResetPasswordService(
+      @Value("${front.urls.reset-password:none}") String resetPasswordUrl,
+      UserRepository userRepository,
+      Auth0CryptoService auth0CryptoService,
+      EmailComposerService emailComposerService,
+      EmailService emailService,
+      URLResolverService urlResolverService) {
+    this.resetPasswordUrl = resetPasswordUrl;
+    this.userRepository = userRepository;
+    this.cryptoService = auth0CryptoService;
+    this.emailComposerService = emailComposerService;
+    this.emailService = emailService;
+    this.urlResolverService = urlResolverService;
+  }
+
+  @Override
+  public void resetPasswordRequest(String userEmail) {
+    final String randomOTP = cryptoService.hash(RandomStringUtils.randomAlphanumeric(17));
+    final Optional<User> user = userRepository.findByEmail(userEmail);
+
+    user.ifPresent(
+        (u) -> {
+          LOG.info(String.format("Notifying user %s to reset her password", u.getEmail()));
+
+          setOTPForUser(randomOTP, u);
+          Email resettingEmail = composeResettingEmail(u);
+          emailService.send(resettingEmail);
+        });
+  }
+
+  private void setOTPForUser(String randomToken, User user) {
+    user.setOtp(randomToken);
+    userRepository.save(user);
+  }
+
+  @SuppressWarnings("PMD.UseConcurrentHashMap")
+  private Email composeResettingEmail(User user) {
+    String emailRecipient = user.getEmail();
+    String emailSubject = emailComposerService.getMessage("resetPassword.subject");
+    String emailMainMessage = emailComposerService.getMessage("resetPassword.main");
+    String emailBodyTemplate = emailComposerService.getMessage("resetPassword.bodyTemplate");
+
+    Map<String, Object> greetingMessageVars = Map.of("username", user.getName());
+    String greetingsMessage =
+        emailComposerService.getMessage("resetPassword.greetings", greetingMessageVars);
+    String thanksMessage = emailComposerService.getMessage("resetPassword.thanks");
+
+    Map<String, Object> emailBodyVars = new HashMap<>();
+    emailBodyVars.put("subject", emailSubject);
+    emailBodyVars.put("greetings", greetingsMessage);
+    emailBodyVars.put("main", emailMainMessage);
+    emailBodyVars.put("link", this.getChangePasswordLink(user.getId(), user.getOtp()));
+    emailBodyVars.put("thanks", thanksMessage);
+
+    return emailComposerService.composeEmail(
+        emailRecipient, emailSubject, emailBodyTemplate, emailBodyVars);
+  }
+
+  private String getChangePasswordLink(UUID userId, String userOTP) {
+    return urlResolverService.resolve(this.resetPasswordUrl, userId, userOTP);
+  }
+}

--- a/src/main/java/dwbh/api/services/internal/EmailComposerService.java
+++ b/src/main/java/dwbh/api/services/internal/EmailComposerService.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.services.internal;
+
+import dwbh.api.domain.Email;
+import dwbh.api.services.EmailComposer;
+import dwbh.api.services.internal.templates.JadeTemplateService;
+import io.micronaut.context.MessageSource;
+import io.micronaut.context.annotation.Value;
+import java.text.DateFormat;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.TextStyle;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import javax.inject.Singleton;
+import javax.transaction.Transactional;
+
+/**
+ * Business logic regarding the composition of an {@link Email}
+ *
+ * @since 0.1.0
+ */
+@Singleton
+@Transactional
+public class EmailComposerService implements EmailComposer {
+
+  private static final Locale DEFAULT_LOCALE = Locale.ENGLISH;
+
+  private final transient JadeTemplateService jadeTemplateService;
+  private final transient MessageSource messageSource;
+  private final transient Locale locale;
+
+  /**
+   * Different methods and utilities regarding the composition of an email
+   *
+   * @param jadeTemplateService to allow templates in the email composition
+   * @param messageSource bundle to get i18n messages from
+   * @param locale from configuration to internationalize dates and texts
+   * @since 0.1.0
+   */
+  public EmailComposerService(
+      JadeTemplateService jadeTemplateService,
+      MessageSource messageSource,
+      @Value("${locale}") Optional<String> locale) {
+    this.jadeTemplateService = jadeTemplateService;
+    this.messageSource = messageSource;
+    this.locale = locale.map(Locale::new).orElse(DEFAULT_LOCALE);
+  }
+
+  /**
+   * @param recipient the email recipient (jsmith@example.com)
+   * @param subject the email subject
+   * @param bodyTemplate the path where the .pug template is, to generate the html of the email body
+   * @param bodyVariables a Map with the required variables to compose the bodyTemplate
+   * @return the composed {@link Email}
+   */
+  @Override
+  public Email composeEmail(
+      String recipient, String subject, String bodyTemplate, Map<String, Object> bodyVariables) {
+    String body = jadeTemplateService.render(bodyTemplate, bodyVariables);
+
+    return Email.builder()
+        .with(email -> email.setRecipient(recipient))
+        .with(email -> email.setSubject(subject))
+        .with(email -> email.setTextBody(body))
+        .build();
+  }
+
+  /**
+   * Recovers a message from 'messages.properties' files (for the configuration locale) with
+   * variables to interpolate
+   *
+   * @param key the key in a 'messages.properties' file
+   * @param variables the variables to interpolate for that entry key
+   * @return the text message
+   */
+  @Override
+  public String getMessage(String key, Map<String, Object> variables) {
+    MessageSource.MessageContext context = MessageSource.MessageContext.of(this.locale, variables);
+
+    return this.getInterpolatedMessage(key, context);
+  }
+
+  /**
+   * Recovers a message from 'messages.properties' files (for the configuration locale) with NO
+   * variables to interpolate
+   *
+   * @param key the key in a 'messages.properties' file
+   * @return the text message
+   */
+  @Override
+  public String getMessage(String key) {
+    MessageSource.MessageContext context = MessageSource.MessageContext.of(this.locale);
+
+    return this.getInterpolatedMessage(key, context);
+  }
+
+  @Override
+  /**
+   * Get a composed message representing the current date
+   *
+   * @return the textual date
+   */
+  public String getTodayMessage() {
+    String dayOfTheWeek = this.getDayOfTheWeek();
+    DateFormat formatter = DateFormat.getDateInstance(DateFormat.SHORT, this.locale);
+    String today = formatter.format(new Date());
+
+    return String.format("%s, %s", dayOfTheWeek, today);
+  }
+
+  private String getInterpolatedMessage(String key, MessageSource.MessageContext context) {
+    String template = this.messageSource.getMessage(key, context).orElse("");
+
+    return messageSource.interpolate(template, context);
+  }
+
+  private String getDayOfTheWeek() {
+    LocalDate today = LocalDate.now();
+    DayOfWeek dayOfWeek = today.getDayOfWeek();
+
+    return dayOfWeek.getDisplayName(TextStyle.FULL, this.locale);
+  }
+}

--- a/src/main/java/dwbh/api/services/internal/VotingSchedulingService.java
+++ b/src/main/java/dwbh/api/services/internal/VotingSchedulingService.java
@@ -25,24 +25,16 @@ import dwbh.api.repositories.GroupRepository;
 import dwbh.api.repositories.VotingRepository;
 import dwbh.api.services.EmailService;
 import dwbh.api.services.VotingScheduling;
-import dwbh.api.services.internal.templates.JadeTemplateService;
 import dwbh.api.services.internal.templates.URLResolverService;
-import io.micronaut.context.MessageSource;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.scheduling.annotation.Scheduled;
-import java.text.DateFormat;
 import java.time.DayOfWeek;
-import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
-import java.time.format.TextStyle;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -61,44 +53,39 @@ import org.slf4j.LoggerFactory;
 public class VotingSchedulingService implements VotingScheduling {
 
   private static final Logger LOG = LoggerFactory.getLogger(VotingSchedulingService.class);
-  private static final Locale DEFAULT_LOCALE = Locale.ENGLISH;
 
+  private final transient String votingUrl;
   private final transient GroupRepository groupRepository;
   private final transient VotingRepository votingRepository;
+  private final transient EmailComposerService emailComposerService;
   private final transient EmailService emailService;
-  private final transient JadeTemplateService jadeTemplateService;
   private final transient URLResolverService urlResolverService;
-  private final transient MessageSource messageSource;
-  private final transient Locale locale;
 
   /**
    * Requires the {@link DefaultVotingService} to get group voting information and {@link
    * EmailService} to be able to send notification to group members
    *
+   * @param votingUrl to get the link from configuration
    * @param groupRepository to be able to get group details
    * @param votingRepository to be able to create a new {@link dwbh.api.domain.Voting}
+   * @param emailComposerService service to compose the {@link Email} notifications
    * @param emailService to be able to send notifications to group members
-   * @param jadeTemplateService service to render email template
    * @param urlResolverService to resolve possible link urls for emails
-   * @param messageSource bundle to get i18n messages from
-   * @param locale from configuration to internationalize dates
    * @since 0.1.0
    */
   public VotingSchedulingService(
+      @Value("${front.urls.voting:none}") String votingUrl,
       GroupRepository groupRepository,
       VotingRepository votingRepository,
+      EmailComposerService emailComposerService,
       EmailService emailService,
-      JadeTemplateService jadeTemplateService,
-      URLResolverService urlResolverService,
-      MessageSource messageSource,
-      @Value("${locale}") Optional<String> locale) {
+      URLResolverService urlResolverService) {
+    this.votingUrl = votingUrl;
     this.groupRepository = groupRepository;
     this.votingRepository = votingRepository;
+    this.emailComposerService = emailComposerService;
     this.emailService = emailService;
-    this.jadeTemplateService = jadeTemplateService;
     this.urlResolverService = urlResolverService;
-    this.messageSource = messageSource;
-    this.locale = locale.map(Locale::new).orElse(DEFAULT_LOCALE);
   }
 
   @Override
@@ -150,74 +137,38 @@ public class VotingSchedulingService implements VotingScheduling {
     LOG.info(String.format("notifying members or group %s", group.getId()));
 
     group.getUsers().stream()
-        .map(ug -> createEmail(ug.getUser(), ug.getGroup(), voting))
+        .map(ug -> composeEmail(ug.getUser(), ug.getGroup(), voting))
         .forEach(emailService::send);
   }
 
   @SuppressWarnings("PMD.UseConcurrentHashMap")
-  private Email createEmail(User user, Group group, Voting voting) {
-    Map<String, Object> votingSubjectVars =
+  private Email composeEmail(User user, Group group, Voting voting) {
+    String emailBodyTemplate = emailComposerService.getMessage("voting.bodyTemplate");
+    String emailRecipient = user.getEmail();
+
+    Map<String, Object> subjectMessageVars =
         Map.of(
-            "today", this.getTodayAsString(),
+            "today", emailComposerService.getTodayMessage(),
             "groupName", group.getName());
-    Map<String, Object> votingGreetingVars = Map.of("username", user.getName());
+    String emailSubject = emailComposerService.getMessage("voting.subject", subjectMessageVars);
 
-    String subject = this.getMessage("voting.subject", votingSubjectVars);
-    String greetings = this.getMessage("voting.greetings", votingGreetingVars);
-    String template = this.getMessage("voting.template");
-    String thanks = this.getMessage("voting.thanks");
+    Map<String, Object> greetingMessageVars = Map.of("username", user.getName());
+    String greetingsMessage =
+        emailComposerService.getMessage("voting.greetings", greetingMessageVars);
+    String thanksMessage = emailComposerService.getMessage("voting.thanks");
 
-    Map<String, Object> model = new HashMap<>();
+    Map<String, Object> emailBodyVars = new HashMap<>();
+    emailBodyVars.put("question", emailSubject);
+    emailBodyVars.put("greetings", greetingsMessage);
+    emailBodyVars.put("groupName", group.getName());
+    emailBodyVars.put("thanks", thanksMessage);
+    emailBodyVars.put("link", getVotingLink(group.getId(), voting.getId()));
 
-    model.put("question", subject);
-    model.put("greetings", greetings);
-    model.put("groupName", group.getName());
-    model.put("thanks", thanks);
-    model.put("link", getVotingLink(group.getId(), voting.getId()));
-
-    String body = jadeTemplateService.render(template, model);
-
-    return Email.builder()
-        .with(email -> email.setRecipient(user.getEmail()))
-        .with(email -> email.setSubject(subject))
-        .with(email -> email.setTextBody(body))
-        .build();
+    return emailComposerService.composeEmail(
+        emailRecipient, emailSubject, emailBodyTemplate, emailBodyVars);
   }
 
   private String getVotingLink(UUID groupId, UUID votingId) {
-    return urlResolverService.resolve("/groups/{0}/votings/{1}/vote", groupId, votingId);
-  }
-
-  private String getDayOfTheWeek() {
-    LocalDate today = LocalDate.now();
-    DayOfWeek dayOfWeek = today.getDayOfWeek();
-
-    return dayOfWeek.getDisplayName(TextStyle.FULL, this.locale);
-  }
-
-  private String getTodayAsString() {
-    String dayOfTheWeek = this.getDayOfTheWeek();
-    DateFormat formatter = DateFormat.getDateInstance(DateFormat.SHORT, this.locale);
-    String today = formatter.format(new Date());
-
-    return String.format("%s, %s", dayOfTheWeek, today);
-  }
-
-  private String getMessage(String key, Map<String, Object> variables) {
-    MessageSource.MessageContext context = MessageSource.MessageContext.of(this.locale, variables);
-
-    return getInterpolatedMessage(key, context);
-  }
-
-  private String getMessage(String key) {
-    MessageSource.MessageContext context = MessageSource.MessageContext.of(this.locale);
-
-    return getInterpolatedMessage(key, context);
-  }
-
-  private String getInterpolatedMessage(String key, MessageSource.MessageContext context) {
-    String template = this.messageSource.getMessage(key, context).orElse("");
-
-    return this.messageSource.interpolate(template, context);
+    return urlResolverService.resolve(this.votingUrl, groupId, votingId);
   }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -87,3 +87,8 @@ templates:
   cached: false
   encoding: UTF-8
   path: /templates
+
+front:
+  urls:
+    voting: "/groups/{0}/votings/{1}/vote"
+    reset-password: "/user/{0}/reset?otp={1}"

--- a/src/main/resources/application.yml.template
+++ b/src/main/resources/application.yml.template
@@ -86,3 +86,8 @@ templates:
   cached: false
   encoding: UTF-8
   path: /templates
+
+front:
+  urls:
+    voting: "/groups/{0}/votings/{1}/vote"
+    reset-password: "/user/{0}/reset?otp={1}"

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -107,6 +107,9 @@ type Query {
 
 # registered mutations
 type Mutation {
+    # request to initiate the process to reset the password for a user
+    resetPassword(email: String!): Boolean
+
     # creates a new voting slot
     createVoting(groupId: ID): Voting
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -19,4 +19,10 @@
 voting.subject=Today is {today}. Are you happy in {groupName} ? 
 voting.greetings=Hello {username}!
 voting.thanks=Thanks for voting :)
-voting.template=templates/voting.pug
+voting.bodyTemplate=templates/voting.pug
+
+resetPassword.subject=Instructions to reset your password
+resetPassword.greetings=Hello {username}!
+resetPassword.main=To reset your password simply click the following link and follow the instructions
+resetPassword.thanks=Best Regards
+resetPassword.bodyTemplate=templates/resetPassword.pug

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -19,4 +19,10 @@
 voting.subject=Hoy es {today}. Estás feliz en {groupName} ? 
 voting.greetings=Hola {username}!
 voting.thanks=Gracias por votar :)
-voting.template=templates/voting.pug
+voting.bodyTemplate=templates/voting.pug
+
+resetPassword.subject=Instrucciones para resetear tu contraseña
+resetPassword.greetings=Hola {username}!
+resetPassword.main=Sigue las instrucciones del siguiente enlace para cambiar tu contraseña
+resetPassword.thanks=Un saludo
+resetPassword.bodyTemplate=templates/resetPassword.pug

--- a/src/main/resources/messages_fr.properties
+++ b/src/main/resources/messages_fr.properties
@@ -19,4 +19,10 @@
 voting.subject=Aujourd'hui nous sommes {today}. Êtes-vous heureux dans {groupName} ?
 voting.greetings=Bonjour {username}!
 voting.thanks=Merci d'avoir voté :)
-voting.template=templates/voting.pug
+voting.bodyTemplate=templates/voting.pug
+
+resetPassword.subject=Instructions pour réinitialiser votre mot de passe
+resetPassword.greetings=Bonjour {username}!
+resetPassword.main=Suivez les instructions sur le lien suivant pour changer votre mot de passe
+resetPassword.thanks=Au revoir
+resetPassword.bodyTemplate=templates/resetPassword.pug

--- a/src/main/resources/templates/resetPassword.pug
+++ b/src/main/resources/templates/resetPassword.pug
@@ -1,0 +1,8 @@
+div
+    p #{greetings}
+    p #{main}
+    p
+      div
+        a(href='#{link}') #{link}
+
+    p #{thanks}

--- a/src/test/java/dwbh/api/graphql/GraphQLFactoryTest.java
+++ b/src/test/java/dwbh/api/graphql/GraphQLFactoryTest.java
@@ -28,6 +28,7 @@ import dwbh.api.domain.Group;
 import dwbh.api.domain.User;
 import dwbh.api.graphql.fetchers.FetcherProvider;
 import dwbh.api.graphql.fetchers.GroupFetcher;
+import dwbh.api.graphql.fetchers.ResetPasswordFetcher;
 import dwbh.api.graphql.fetchers.SecurityFetcher;
 import dwbh.api.graphql.fetchers.UserFetcher;
 import dwbh.api.graphql.fetchers.UserGroupFetcher;
@@ -63,6 +64,9 @@ class GraphQLFactoryTest {
 
     // and: adding security fetcher to fetcher providers
     fetchers.setSecurityFetcher(mock(SecurityFetcher.class));
+
+    // and: adding user password fetcher to fetcher providers
+    fetchers.setResetPasswordFetcher(mock(ResetPasswordFetcher.class));
 
     // when: creating a valid GraphQL engine
     var resolver = new ResourceResolver();

--- a/src/test/java/dwbh/api/graphql/fetchers/ResetPasswordFetcherTests.java
+++ b/src/test/java/dwbh/api/graphql/fetchers/ResetPasswordFetcherTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.graphql.fetchers;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+
+import dwbh.api.domain.Email;
+import dwbh.api.domain.User;
+import dwbh.api.graphql.fetchers.utils.FetcherTestUtils;
+import dwbh.api.services.internal.DefaultResetPasswordService;
+import dwbh.api.services.internal.EmailComposerService;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Tests {@link UserFetcher} class
+ *
+ * @since 0.1.0
+ */
+public class ResetPasswordFetcherTests {
+
+  @Test
+  void testResetPassword() {
+    // given: a user
+    User user = random(User.class);
+
+    // given: mocked services
+    var mockedService = Mockito.mock(DefaultResetPasswordService.class);
+    var emailComposerService = Mockito.mock(EmailComposerService.class);
+
+    // and: a mocked environment
+    var mockedEnvironment =
+        FetcherTestUtils.generateMockedEnvironment(user, Map.of("email", user.getEmail()));
+
+    // when: fetching user list invoking the service
+    ResetPasswordFetcher fetchers = new ResetPasswordFetcher(mockedService);
+    fetchers.resetPassword(mockedEnvironment);
+
+    // then: check certain assertions should be met
+    assertThat("The user's OTP is now defined", user.getOtp(), is(not(isEmptyString())));
+    Mockito.when(emailComposerService.composeEmail(any(), any(), any(), any()))
+        .thenReturn(random(Email.class));
+  }
+}

--- a/src/test/java/dwbh/api/repositories/VotingRepositoryTests.java
+++ b/src/test/java/dwbh/api/repositories/VotingRepositoryTests.java
@@ -43,7 +43,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
- * Tests DATABASE integration regarding {@link Voting} persistence
+ * Tests DATABASE integration regarding {@link Voting} persistence.
  *
  * @since 0.1.0
  */

--- a/src/test/java/dwbh/api/services/EmailComposerServiceTests.java
+++ b/src/test/java/dwbh/api/services/EmailComposerServiceTests.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.services;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+
+import dwbh.api.services.internal.EmailComposerService;
+import dwbh.api.services.internal.templates.JadeTemplateService;
+import io.micronaut.context.MessageSource;
+import java.util.HashMap;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Tests {@link EmailComposerService}
+ *
+ * @since 0.1.0
+ */
+public class EmailComposerServiceTests {
+
+  @Test
+  void testComposeEmail() {
+    // given: the email parts to be composed together
+    var recipient = "jSmith@example.com";
+    var subject = random(String.class);
+    var bodyTemplate = random(String.class);
+    var bodyVariables = new HashMap<String, Object>();
+
+    // and: a mocked jadeTemplateService service
+    var jadeTemplateService = Mockito.mock(JadeTemplateService.class);
+    Mockito.when(jadeTemplateService.render(any(), any())).thenReturn(random(String.class));
+
+    // and: a mocked messageSource service
+    var messageSource = Mockito.mock(MessageSource.class);
+
+    // and: an english locale
+    var locale = Optional.of("eng");
+
+    // when: invoking composeEmail()
+    var emailComposerService = new EmailComposerService(jadeTemplateService, messageSource, locale);
+
+    var emailResult =
+        emailComposerService.composeEmail(recipient, subject, bodyTemplate, bodyVariables);
+
+    // then: we should get an email with all of its parts
+    assertThat("The recipient is the same", emailResult.getRecipient(), is(recipient));
+    assertThat("The subject is the same", emailResult.getSubject(), is(subject));
+    assertThat("The text body exists", emailResult.getTextBody(), is(not(isEmptyString())));
+
+    // and: jadeTemplateService is called to render the text body
+    verify(jadeTemplateService, atLeast(1)).render(bodyTemplate, bodyVariables);
+  }
+
+  @Test
+  void testGetMessageNoInterpolation() {
+    // given: a key and its text message
+    var key = "sample.key";
+    var retMessage = "sample text message";
+
+    // mocked jadeTemplateService service
+    var jadeTemplateService = Mockito.mock(JadeTemplateService.class);
+
+    // and: a locale with its mocked context
+    var locale = Optional.of("");
+    var messageSource = Mockito.mock(MessageSource.class);
+    Mockito.when(messageSource.interpolate(any(), any())).thenReturn(retMessage);
+    Mockito.when(messageSource.getMessage(any(), any())).thenReturn(Optional.of(retMessage));
+
+    // when: invoking getMessage() with no variables to interpolate
+    var emailComposerService = new EmailComposerService(jadeTemplateService, messageSource, locale);
+
+    // then: it should return the message
+    assertThat("The retMessage is returned", emailComposerService.getMessage(key), is(retMessage));
+  }
+
+  @Test
+  void testGetMessageInterpolation() {
+    // given: a key and its text message
+    var key = "sample.key";
+    var retMessage = "Hello {name}";
+
+    // and: some variables to interpolate
+    var vars = new HashMap<String, Object>();
+    vars.put("name", "Charles Xavier");
+
+    // mocked jadeTemplateService service
+    var jadeTemplateService = Mockito.mock(JadeTemplateService.class);
+
+    // and: a locale with its mocked context
+    var locale = Optional.of("");
+    var messageSource = Mockito.mock(MessageSource.class);
+    Mockito.when(messageSource.interpolate(any(), any())).thenReturn(retMessage);
+    Mockito.when(messageSource.getMessage(any(), any())).thenReturn(Optional.of(retMessage));
+
+    // when: invoking getMessage() with no variables to interpolate
+    var emailComposerService = new EmailComposerService(jadeTemplateService, messageSource, locale);
+
+    // then: it should return the message
+    assertThat(
+        "The retMessage is returned", emailComposerService.getMessage(key, vars), is(retMessage));
+  }
+}

--- a/src/test/java/dwbh/api/services/ResetPasswordServiceTests.java
+++ b/src/test/java/dwbh/api/services/ResetPasswordServiceTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.services;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+
+import dwbh.api.domain.Email;
+import dwbh.api.domain.User;
+import dwbh.api.repositories.UserRepository;
+import dwbh.api.services.internal.Auth0CryptoService;
+import dwbh.api.services.internal.DefaultResetPasswordService;
+import dwbh.api.services.internal.EmailComposerService;
+import dwbh.api.services.internal.templates.URLResolverService;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Tests {@link DefaultResetPasswordService}
+ *
+ * @since 0.1.0
+ */
+public class ResetPasswordServiceTests {
+
+  @Test
+  void testResetPasswordRequest() {
+    // given: a user
+    User user = random(User.class);
+
+    // given: a mocked repositories and services
+    var userRepository = Mockito.mock(UserRepository.class);
+    Mockito.when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+
+    // and: a new randomly-generated One-time Password (OTP)
+    var randomOTP = "$2a$10$ccXSNGubl.ja9eV2Dfrxmhd9t";
+    var auth0CryptoService = Mockito.mock(Auth0CryptoService.class);
+    Mockito.when(auth0CryptoService.hash(any())).thenReturn(randomOTP);
+
+    // and: other mocked services
+    var emailComposerService = Mockito.mock(EmailComposerService.class);
+    var emailService = Mockito.mock(EmailService.class);
+    var urlResolverService = Mockito.mock(URLResolverService.class);
+
+    // when: invoking service resetPasswordRequest()
+    var defaultResetPasswordService =
+        new DefaultResetPasswordService(
+            "/user/{0}/reset?otp={1}",
+            userRepository,
+            auth0CryptoService,
+            emailComposerService,
+            emailService,
+            urlResolverService);
+    defaultResetPasswordService.resetPasswordRequest(user.getEmail());
+
+    // then: we should set an OTP for the user
+    assertThat("The user's OTP is now defined", user.getOtp(), is(randomOTP));
+    verify(emailComposerService, atLeast(1)).composeEmail(any(), any(), any(), any());
+
+    // and: an password resetting email is generated
+    Mockito.when(emailComposerService.composeEmail(any(), any(), any(), any()))
+        .thenReturn(random(Email.class));
+
+    // and: the email finally gets send
+    verify(emailService, atLeast(1)).send(any());
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -61,3 +61,8 @@ email:
 
       Cheers
       Admin
+
+front:
+  urls:
+    voting: "/groups/{0}/votings/{1}/vote"
+    reset-password: "/user/{0}/reset?otp={1}"


### PR DESCRIPTION
This is the first part of two (1/2) of the US to reset a user password
https://tree.taiga.io/project/pabloruiz-kaleidos-patio/us/1

![gif](https://as01.epimg.net/epik/imagenes/2020/04/21/portada/1587462940_539238_1587463032_noticia_normal.jpg)

Validation tests
- [x] Review the code
- [x] Execute the 'resetUserPassword' mutation
- [x] Check the user now has an OTP in database
- [x] Check an email has been sent for that user
- [x] Check the email recipient, subject and text body is correct
- [x] Check the URL link in the email is also valid, and includes the same previous OTP
- [x] Check changing the locale (blank/fr/es) the email language changes
- [x] Check voting emails keep being sent as well

```
mutation {
  resetUserPassword(
    email: "daniel.herrero@kaleidos.net"
  ) 
}
```

