### PR TITLE
feat(back): allows to login by otp & set a new password

### DIFF
--- a/src/main/java/dwbh/api/domain/input/ChangePasswordInput.java
+++ b/src/main/java/dwbh/api/domain/input/ChangePasswordInput.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.domain.input;
+
+import java.util.UUID;
+
+/**
+ * Input to change the password for a user
+ *
+ * @since 0.1.0
+ */
+public class ChangePasswordInput {
+
+  private final UUID userId;
+  private final String password;
+
+  /**
+   * Returns input's userId
+   *
+   * @return input's userId
+   * @since 0.1.0
+   */
+  public UUID getUserId() {
+    return userId;
+  }
+
+  /**
+   * Returns the input's password
+   *
+   * @return input password
+   * @since 0.1.0
+   */
+  public String getPassword() {
+    return password;
+  }
+
+  /**
+   * Initializes the input to allow using the service
+   *
+   * @param userId user's email
+   * @param password user's password
+   * @since 0.1.0
+   */
+  public ChangePasswordInput(UUID userId, String password) {
+    this.userId = userId;
+    this.password = password;
+  }
+
+  /**
+   * Creates a new builder to create a new instance of type {@link ChangePasswordInput}
+   *
+   * @return an instance of {@link GetGroupInput.Builder}
+   * @since 0.1.0
+   */
+  public static Builder newBuilder() {
+    return new ChangePasswordInput.Builder();
+  }
+
+  /**
+   * Builds an instance of type {@link ChangePasswordInput}
+   *
+   * @since 0.1.0
+   */
+  public static class Builder {
+
+    private transient ChangePasswordInput input = new ChangePasswordInput(null, null);
+
+    private Builder() {
+      /* empty */
+    }
+
+    /**
+     * Sets the userId
+     *
+     * @param userId the current user's id
+     * @return current builder instance
+     * @since 0.1.0
+     */
+    public ChangePasswordInput.Builder withUserId(UUID userId) {
+      this.input = new ChangePasswordInput(userId, input.getPassword());
+      return this;
+    }
+
+    /**
+     * Sets the password
+     *
+     * @param password the new password for the user
+     * @return the builder
+     * @since 0.1.0
+     */
+    public ChangePasswordInput.Builder withPassword(String password) {
+      this.input = new ChangePasswordInput(input.getUserId(), password);
+      return this;
+    }
+
+    /**
+     * Returns the instance built with this builder
+     *
+     * @return an instance of type {@link ChangePasswordInput}
+     * @since 0.1.0
+     */
+    public ChangePasswordInput build() {
+      return this.input;
+    }
+  }
+}

--- a/src/main/java/dwbh/api/graphql/GraphQLFactory.java
+++ b/src/main/java/dwbh/api/graphql/GraphQLFactory.java
@@ -120,8 +120,9 @@ public class GraphQLFactory {
                         .dataFetcher("listUserVotesInGroup", votingFetcher::listUserVotesInGroup)
                         .dataFetcher("myProfile", userFetcher::getCurrentUser)
                         .dataFetcher("getVoting", votingFetcher::getVoting)
-                        .dataFetcher("login", securityFetcher::login)
-                        .dataFetcher("loginOauth2", securityFetcher::loginOauth2))
+                        .dataFetcher("login", securityFetcher::loginByCredentials)
+                        .dataFetcher("loginOauth2", securityFetcher::loginByOauth2)
+                        .dataFetcher("loginOtp", securityFetcher::loginByOtp))
             .type(
                 SCHEMA_TYPE_MUTATION,
                 builder ->
@@ -132,7 +133,8 @@ public class GraphQLFactory {
                         .dataFetcher("resetPassword", resetPasswordFetcher::resetPassword)
                         .dataFetcher("createVoting", votingFetcher::createVoting)
                         .dataFetcher("createVote", votingFetcher::createVote)
-                        .dataFetcher("leaveGroup", userGroupFetcher::leaveGroup))
+                        .dataFetcher("leaveGroup", userGroupFetcher::leaveGroup)
+                        .dataFetcher("changePassword", securityFetcher::changePassword))
             .type(
                 "Group",
                 builder ->

--- a/src/main/java/dwbh/api/graphql/fetchers/SecurityFetcher.java
+++ b/src/main/java/dwbh/api/graphql/fetchers/SecurityFetcher.java
@@ -18,6 +18,8 @@
 package dwbh.api.graphql.fetchers;
 
 import dwbh.api.domain.Login;
+import dwbh.api.domain.User;
+import dwbh.api.domain.input.ChangePasswordInput;
 import dwbh.api.domain.input.LoginInput;
 import dwbh.api.graphql.ResultUtils;
 import dwbh.api.services.SecurityService;
@@ -53,9 +55,9 @@ public class SecurityFetcher {
    * @return an instance of {@link DataFetcherResult} because it could return errors
    * @since 0.1.0
    */
-  public DataFetcherResult<Login> login(DataFetchingEnvironment environment) {
+  public DataFetcherResult<Login> loginByCredentials(DataFetchingEnvironment environment) {
     LoginInput input = SecurityFetcherUtils.login(environment);
-    Result<Login> login = securityService.login(input);
+    Result<Login> login = securityService.loginByCredentials(input);
 
     return ResultUtils.render(login);
   }
@@ -67,11 +69,39 @@ public class SecurityFetcher {
    * @return an instance of {@link DataFetcherResult} because it could return errors
    * @since 0.1.0
    */
-  public DataFetcherResult<Login> loginOauth2(DataFetchingEnvironment environment) {
+  public DataFetcherResult<Login> loginByOauth2(DataFetchingEnvironment environment) {
     String authorizationCode = environment.getArgument("authorizationCode");
 
-    Result<Login> login = securityService.login(authorizationCode);
+    Result<Login> login = securityService.loginByOauth2(authorizationCode);
 
     return ResultUtils.render(login);
+  }
+
+  /**
+   * Fetcher responsible to handle the user's login using an OTP (one-time password) code
+   *
+   * @param environment GraphQL execution environment
+   * @return an instance of {@link DataFetcherResult} because it could return errors
+   * @since 0.1.0
+   */
+  public DataFetcherResult<Login> loginByOtp(DataFetchingEnvironment environment) {
+    String otpCode = environment.getArgument("otpCode");
+
+    Result<Login> login = securityService.loginByOtp(otpCode);
+
+    return ResultUtils.render(login);
+  }
+
+  /**
+   * Fetcher responsible of changing the password for a {@link User}.
+   *
+   * @param env GraphQL execution environment
+   * @return an instance of {@link DataFetcherResult} because it could return errors
+   * @since 0.1.0
+   */
+  public DataFetcherResult<Boolean> changePassword(DataFetchingEnvironment env) {
+    ChangePasswordInput input = SecurityFetcherUtils.changePassword(env);
+
+    return ResultUtils.render(securityService.changePassword(input));
   }
 }

--- a/src/main/java/dwbh/api/graphql/fetchers/SecurityFetcherUtils.java
+++ b/src/main/java/dwbh/api/graphql/fetchers/SecurityFetcherUtils.java
@@ -17,7 +17,10 @@
  */
 package dwbh.api.graphql.fetchers;
 
+import dwbh.api.domain.User;
+import dwbh.api.domain.input.ChangePasswordInput;
 import dwbh.api.domain.input.LoginInput;
+import dwbh.api.graphql.Context;
 import graphql.schema.DataFetchingEnvironment;
 
 /**
@@ -45,5 +48,24 @@ final class SecurityFetcherUtils {
     String password = environment.getArgument("password");
 
     return new LoginInput(email, password);
+  }
+
+  /**
+   * Creates a {@link ChangePasswordInput} from the data coming from the {@link
+   * DataFetchingEnvironment}
+   *
+   * @param environment the GraphQL {@link DataFetchingEnvironment}
+   * @return an instance of {@link ChangePasswordInput}
+   * @since 0.1.0
+   */
+  /* default */ static ChangePasswordInput changePassword(DataFetchingEnvironment environment) {
+    Context ctx = environment.getContext();
+    User currentUser = ctx.getAuthenticatedUser();
+    String password = environment.getArgument("password");
+
+    return ChangePasswordInput.newBuilder()
+        .withUserId(currentUser.getId())
+        .withPassword(password)
+        .build();
   }
 }

--- a/src/main/java/dwbh/api/repositories/UserRepository.java
+++ b/src/main/java/dwbh/api/repositories/UserRepository.java
@@ -56,7 +56,15 @@ public interface UserRepository extends PageableRepository<User, UUID> {
    * Gets a persisted {@link User} by its email
    *
    * @param email the user's email
-   * @return and {@link Optional} of the {@link User}
+   * @return an {@link Optional} of the {@link User}
    */
   Optional<User> findByEmail(String email);
+
+  /**
+   * Gets a persisted {@link User} by its OTP
+   *
+   * @param otpCode the user's OTP code
+   * @return an {@link Optional} of the {@link User}
+   */
+  Optional<User> findByOtp(String otpCode);
 }

--- a/src/main/java/dwbh/api/services/SecurityService.java
+++ b/src/main/java/dwbh/api/services/SecurityService.java
@@ -19,6 +19,7 @@ package dwbh.api.services;
 
 import dwbh.api.domain.Login;
 import dwbh.api.domain.User;
+import dwbh.api.domain.input.ChangePasswordInput;
 import dwbh.api.domain.input.LoginInput;
 import dwbh.api.util.Result;
 import java.util.Optional;
@@ -50,7 +51,7 @@ public interface SecurityService {
    * @return an instance of {@link Result} ({@link Login} | {@link Error})
    * @since 0.1.0
    */
-  Result<Login> login(LoginInput input);
+  Result<Login> loginByCredentials(LoginInput input);
 
   /**
    * When using oauth2 authorization code, this service will make use of the configured oauth2
@@ -61,7 +62,17 @@ public interface SecurityService {
    * @return an instance of {@link Result} ({@link Login} | {@link Error})
    * @since 0.1.0
    */
-  Result<Login> login(String code);
+  Result<Login> loginByOauth2(String code);
+
+  /**
+   * Validates the {@link User} who possesses the provided OTP (one-time password). If so, the app
+   * will return an instance of {@link Login}.
+   *
+   * @param otpCode a valid OTP code
+   * @return an instance of {@link Result} ({@link Login} | {@link Error})
+   * @since 0.1.0
+   */
+  Result<Login> loginByOtp(String otpCode);
 
   /**
    * When the authentication token's expired this function will allow the client to make use of the
@@ -72,4 +83,12 @@ public interface SecurityService {
    * @since 0.1.0
    */
   Result<Login> refresh(String refreshToken);
+
+  /**
+   * Changes the password for the given {@link User}
+   *
+   * @param changePasswordInput an instance of {@link ChangePasswordInput}
+   * @return the {@link Result} with either a success or an error list
+   */
+  Result<Boolean> changePassword(ChangePasswordInput changePasswordInput);
 }

--- a/src/main/java/dwbh/api/services/internal/DefaultSecurityService.java
+++ b/src/main/java/dwbh/api/services/internal/DefaultSecurityService.java
@@ -21,17 +21,23 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import dwbh.api.domain.Login;
 import dwbh.api.domain.Tokens;
 import dwbh.api.domain.User;
+import dwbh.api.domain.input.ChangePasswordInput;
 import dwbh.api.domain.input.LoginInput;
 import dwbh.api.repositories.UserRepository;
 import dwbh.api.services.CryptoService;
 import dwbh.api.services.GoogleUserService;
 import dwbh.api.services.OauthService;
 import dwbh.api.services.SecurityService;
+import dwbh.api.services.internal.checkers.NotPresent;
+import dwbh.api.services.internal.checkers.PasswordIsBlank;
+import dwbh.api.services.internal.checkers.SamePassword;
 import dwbh.api.util.ErrorConstants;
 import dwbh.api.util.Result;
 import java.util.Optional;
 import javax.inject.Singleton;
 import javax.transaction.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Service responsible to check the security constraints
@@ -41,6 +47,8 @@ import javax.transaction.Transactional;
 @Singleton
 @Transactional
 public class DefaultSecurityService implements SecurityService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultSecurityService.class);
 
   private final transient CryptoService cryptoService;
   private final transient OauthService oauthService;
@@ -86,7 +94,7 @@ public class DefaultSecurityService implements SecurityService {
   }
 
   @Override
-  public Result<Login> login(LoginInput input) {
+  public Result<Login> loginByCredentials(LoginInput input) {
     Optional<User> user = userRepository.findByEmail(input.getEmail());
 
     return user.filter(
@@ -97,11 +105,21 @@ public class DefaultSecurityService implements SecurityService {
   }
 
   @Override
-  public Result<Login> login(String code) {
+  public Result<Login> loginByOauth2(String code) {
     return Optional.ofNullable(code)
         .flatMap(oauthService::getAccessToken)
         .flatMap(googleUserService::loadFromAccessToken)
         .flatMap(userRepository::findByEmailOrCreate)
+        .flatMap(this::getLoginFromUser)
+        .map(Result::result)
+        .orElse(Result.error(ErrorConstants.BAD_CREDENTIALS));
+  }
+
+  @Override
+  public Result<Login> loginByOtp(String otpCode) {
+    return Optional.ofNullable(otpCode)
+        .flatMap(userRepository::findByOtp)
+        .flatMap(this::clearOtpForUser)
         .flatMap(this::getLoginFromUser)
         .map(Result::result)
         .orElse(Result.error(ErrorConstants.BAD_CREDENTIALS));
@@ -117,9 +135,38 @@ public class DefaultSecurityService implements SecurityService {
         .orElse(Result.error(ErrorConstants.BAD_CREDENTIALS));
   }
 
+  @Override
+  public Result<Boolean> changePassword(ChangePasswordInput input) {
+    Optional<User> user = userRepository.findById(input.getUserId());
+    Optional<String> newPassword = Optional.of(input.getPassword());
+
+    NotPresent notPresent = new NotPresent();
+    PasswordIsBlank passwordIsBlank = new PasswordIsBlank();
+    SamePassword samePassword = new SamePassword(cryptoService);
+
+    LOG.info(String.format("User %s is attempting to set a new password", input.getUserId()));
+
+    return Result.<Boolean>create()
+        .thenCheck(() -> notPresent.check(user))
+        .thenCheck(() -> passwordIsBlank.check(newPassword.get()))
+        .thenCheck(() -> samePassword.check(user.get(), newPassword.get()))
+        .then(() -> updatePasswordIfSuccess(user.get(), input.getPassword()));
+  }
+
   private Optional<Login> getLoginFromUser(User user) {
     Tokens tokens = cryptoService.createTokens(user);
 
     return Optional.of(new Login(tokens, user));
+  }
+
+  private Optional<User> clearOtpForUser(User user) {
+    user.setOtp("");
+
+    return Optional.of(userRepository.save(user));
+  }
+
+  private Boolean updatePasswordIfSuccess(User user, String password) {
+    user.setPassword(cryptoService.hash(password));
+    return Optional.of(user).map(userRepository::save).isPresent();
   }
 }

--- a/src/main/java/dwbh/api/services/internal/checkers/PasswordIsBlank.java
+++ b/src/main/java/dwbh/api/services/internal/checkers/PasswordIsBlank.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.services.internal.checkers;
+
+import static dwbh.api.util.Check.checkIsFalse;
+
+import dwbh.api.util.Check;
+import dwbh.api.util.ErrorConstants;
+import dwbh.api.util.Result;
+
+/**
+ * This checker expects the argument passed is not blank, otherwise it will return a failing {@link
+ * Result}
+ *
+ * @since 0.1.0
+ */
+public class PasswordIsBlank {
+
+  /**
+   * Checks that the argument passed as parameter is not blank. Otherwise will build a failing
+   * {@link Result} containing an error {@link ErrorConstants#NOT_FOUND}
+   *
+   * @param text the object checked
+   * @return a failing {@link Result} if the object is null
+   * @since 0.1.0
+   */
+  public Check check(String text) {
+    return checkIsFalse(text.isBlank(), ErrorConstants.BLANK_PASSWORD);
+  }
+}

--- a/src/main/java/dwbh/api/services/internal/checkers/SamePassword.java
+++ b/src/main/java/dwbh/api/services/internal/checkers/SamePassword.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.services.internal.checkers;
+
+import static dwbh.api.util.Check.checkIsFalse;
+
+import dwbh.api.domain.User;
+import dwbh.api.services.CryptoService;
+import dwbh.api.util.Check;
+import dwbh.api.util.ErrorConstants;
+import dwbh.api.util.Result;
+
+/**
+ * Checks if the user has already defined the same password as the one provided
+ *
+ * @since 0.1.0
+ */
+public class SamePassword {
+
+  private final transient CryptoService cryptoService;
+
+  /**
+   * This checker expects the password being updated to be different
+   *
+   * @param cryptoService an instance of {@link CryptoService}
+   */
+  public SamePassword(CryptoService cryptoService) {
+    this.cryptoService = cryptoService;
+  }
+
+  /**
+   * Checks the new password is not the same the one user already has
+   *
+   * @param user the {@link User}
+   * @param newPassword the new password has to be different
+   * @return a failing {@link Result} if the user has already defined that password
+   * @since 0.1.0
+   */
+  public Check check(User user, String newPassword) {
+    return checkIsFalse(
+        cryptoService.verifyWithHash(newPassword, user.getPassword()),
+        ErrorConstants.SAME_PASSWORD);
+  }
+}

--- a/src/main/java/dwbh/api/util/ErrorConstants.java
+++ b/src/main/java/dwbh/api/util/ErrorConstants.java
@@ -114,6 +114,22 @@ public final class ErrorConstants {
   public static final Error UNIQUE_ADMIN =
       new Error("API_ERRORS.UNIQUE_ADMIN", "The user is the unique admin of the group");
 
+  /**
+   * Error code used when a user is trying to reuse the exact password it's already defined group
+   *
+   * @since 0.1.0
+   */
+  public static final Error SAME_PASSWORD =
+      new Error("API_ERRORS.PASSWORD_IS_THE_SAME", "The password is the same already defined");
+
+  /**
+   * Error code used when a non-blank string is left blank group
+   *
+   * @since 0.1.0
+   */
+  public static final Error BLANK_PASSWORD =
+      new Error("API_ERRORS.PASSWORD_IS_BLANK", "The password cannot be left blank");
+
   private ErrorConstants() {
     /* empty */
   }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -101,6 +101,9 @@ type Query {
     # log in with oauth2 authorization code credentials
     loginOauth2(authorizationCode: String!): Login @anonymousAllowed
 
+    # log in the user who posseses the provided OTP (one-time passowrd)
+    loginOtp(otpCode: String!): Login @anonymousAllowed
+
     # get the current user's profile
     myProfile: UserProfile
 }
@@ -109,6 +112,9 @@ type Query {
 type Mutation {
     # request to initiate the process to reset the password for a user
     resetPassword(email: String!): Boolean
+
+    # change the password for the current user
+    changePassword(password: String!): Boolean
 
     # creates a new voting slot
     createVoting(groupId: ID): Voting

--- a/src/test/java/dwbh/api/graphql/fetchers/SecurityFetcherTests.java
+++ b/src/test/java/dwbh/api/graphql/fetchers/SecurityFetcherTests.java
@@ -26,11 +26,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 
 import dwbh.api.domain.Login;
+import dwbh.api.domain.Tokens;
+import dwbh.api.domain.User;
 import dwbh.api.domain.input.LoginInput;
 import dwbh.api.graphql.I18nGraphQLError;
+import dwbh.api.graphql.fetchers.utils.FetcherTestUtils;
 import dwbh.api.services.SecurityService;
 import dwbh.api.util.Result;
 import graphql.schema.DataFetchingEnvironment;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -42,16 +46,16 @@ import org.mockito.Mockito;
 public class SecurityFetcherTests {
 
   @Test
-  void testLoginSuccess() {
+  void testLoginByCredentialsSuccess() {
     // given: mocking service SUCCESSFUL call
     var securityService = Mockito.mock(SecurityService.class);
-    Mockito.when(securityService.login(any(LoginInput.class)))
+    Mockito.when(securityService.loginByCredentials(any(LoginInput.class)))
         .thenReturn(Result.result(random(Login.class)));
 
     // when: the fetcher is invoked for login query
     var securityFetcher = new SecurityFetcher(securityService);
     var fetchingEnvironment = Mockito.mock(DataFetchingEnvironment.class);
-    var result = securityFetcher.login(fetchingEnvironment);
+    var result = securityFetcher.loginByCredentials(fetchingEnvironment);
 
     // then: there should be no errors
     assertTrue(result.getErrors().isEmpty());
@@ -61,20 +65,134 @@ public class SecurityFetcherTests {
   }
 
   @Test
-  void testLoginFailure() {
+  void testLoginByCredentialsFailure() {
     // given: failure code and message
     var code = "error.code";
     var message = "friendly message";
 
     // and: mocking service FAILING call
     var securityService = Mockito.mock(SecurityService.class);
-    Mockito.when(securityService.login(any(LoginInput.class)))
+    Mockito.when(securityService.loginByCredentials(any(LoginInput.class)))
         .thenReturn(Result.error(code, message));
 
     // when: the fetcher is invoked for login query
     var securityFetcher = new SecurityFetcher(securityService);
     var fetchingEnvironment = Mockito.mock(DataFetchingEnvironment.class);
-    var result = securityFetcher.login(fetchingEnvironment);
+    var result = securityFetcher.loginByCredentials(fetchingEnvironment);
+
+    // then: there should be errors
+    assertFalse(result.getErrors().isEmpty());
+
+    I18nGraphQLError error = (I18nGraphQLError) result.getErrors().get(0);
+    assertEquals(code, error.getCode());
+    assertEquals(message, error.getMessage());
+
+    // and: a login payload should be missing
+    assertNull(result.getData());
+  }
+
+  @Test
+  void testLoginByOtpSuccess() {
+    // given: a user with an otp
+    var otp = random(String.class);
+    var user = User.builder().with(u -> u.setOtp(otp)).build();
+
+    // and: mocking the service with a SUCCESSFUL Login response
+    var securityService = Mockito.mock(SecurityService.class);
+    var login = new Login(random(Tokens.class), user);
+    Mockito.when(securityService.loginByOtp(otp)).thenReturn(Result.result(login));
+
+    // and: a correct parameter from the environment
+    var mockedEnvironment =
+        FetcherTestUtils.generateMockedEnvironment(null, Map.of("otpCode", otp));
+
+    // when: the fetcher is invoked for login by otp query
+    var securityFetcher = new SecurityFetcher(securityService);
+    var result = securityFetcher.loginByOtp(mockedEnvironment);
+
+    // then: there should be no errors
+    assertTrue(result.getErrors().isEmpty());
+
+    // and: a login payload should be returned
+    assertNotNull(result.getData());
+  }
+
+  @Test
+  void testLoginByOtpFailure() {
+    // given: any otp code
+    var otpCode = random(String.class);
+
+    // and: a failure code and message
+    var code = "error.code";
+    var message = "friendly message";
+
+    // and: mocking the service to FAILURE with an error
+    var securityService = Mockito.mock(SecurityService.class);
+    Mockito.when(securityService.loginByOtp(otpCode)).thenReturn(Result.error(code, message));
+
+    // and: a correct parameter received from the environment
+    var mockedEnvironment =
+        FetcherTestUtils.generateMockedEnvironment(null, Map.of("otpCode", otpCode));
+
+    // when: the fetcher is invoked for login query
+    var securityFetcher = new SecurityFetcher(securityService);
+    var result = securityFetcher.loginByOtp(mockedEnvironment);
+
+    // then: there should be errors
+    assertFalse(result.getErrors().isEmpty());
+
+    I18nGraphQLError error = (I18nGraphQLError) result.getErrors().get(0);
+    assertEquals(code, error.getCode());
+    assertEquals(message, error.getMessage());
+
+    // and: a login payload should be missing
+    assertNull(result.getData());
+  }
+
+  @Test
+  void testChangingPasswordSuccess() {
+    // given: a user
+    var user = random(User.class);
+
+    // and: mocking the service with a SUCCESSFUL response
+    var securityService = Mockito.mock(SecurityService.class);
+    Mockito.when(securityService.changePassword(any())).thenReturn(Result.result(true));
+
+    // and: a correct parameter from the environment
+    var mockedEnvironment =
+        FetcherTestUtils.generateMockedEnvironment(user, Map.of("password", random(String.class)));
+
+    // when: the fetcher is invoked for changing the password by otp mutation
+    var securityFetcher = new SecurityFetcher(securityService);
+    var result = securityFetcher.changePassword(mockedEnvironment);
+
+    // then: there should be no errors
+    assertTrue(result.getErrors().isEmpty());
+
+    // and: a login payload should be returned
+    assertNotNull(result.getData());
+  }
+
+  @Test
+  void testChangingPasswordFailure() {
+    // given: a user
+    var user = random(User.class);
+
+    // and: a failure code and message
+    var code = "error.code";
+    var message = "friendly message";
+
+    // and: mocking the service with a FAILURE response
+    var securityService = Mockito.mock(SecurityService.class);
+    Mockito.when(securityService.changePassword(any())).thenReturn(Result.error(code, message));
+
+    // and: a correct parameter from the environment
+    var mockedEnvironment =
+        FetcherTestUtils.generateMockedEnvironment(user, Map.of("password", random(String.class)));
+
+    // when: the fetcher is invoked for changing the password by otp mutation
+    var securityFetcher = new SecurityFetcher(securityService);
+    var result = securityFetcher.changePassword(mockedEnvironment);
 
     // then: there should be errors
     assertFalse(result.getErrors().isEmpty());


### PR DESCRIPTION
It allows to log in the application using an OTP code (received by email as a request to reset a user's password) already defined by a user.

It allows a user to change the password once logged

![gif](https://media.giphy.com/media/It8qXjo51Rgek/giphy.gif)

Validation tests

- [x] Check the code
- [x] Log in the application using the OTP code a user has received by email https://github.com/dont-worry-be-happy/dwbh-api/pull/71
- [x] Change the password for a user (not blank, can't be the same old password)
- [x] Log in the application by credentials using the new password

```
query {
    loginOtp(otpCode: "$2a$10$L0gD4C9DBy6fQ9fhL3S7Xury7OcUFsXyP.dy0b3qunjtnbVi.FQ96")  {
    tokens {
      authenticationToken
    }
  }
```
```
  mutation {
  	changePassword(password: "new password" ) 
  }
```
```
query {
    login(email: "tstark@email.com", password: "new password") {
      tokens {
        authenticationToken
      }
  }
}
```