### PR TITLE
Fetcher providers change

### DIFF
--- a/src/main/java/dwbh/api/graphql/GraphQLSchemaFactory.java
+++ b/src/main/java/dwbh/api/graphql/GraphQLSchemaFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.graphql;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import javax.inject.Singleton;
+
+/**
+ * This factory creates the {@link GraphQLSchema} instance. In order to create the {@link
+ * GraphQLSchema} it needs to load
+ *
+ * <ul>
+ *   <li>The {@link TypeDefinitionRegistry} which is basically the AST of the GraphQL schema file
+ *   <li>{@link QueryProvider} list: {@link DataFetcher} mappings for queries
+ *   <li>{@link MutationProvider} list: {@link DataFetcher} mappings for mutations
+ *   <li>{@link TypeProvider} list: instances providing field resolution for GraphQL types
+ *   <li>{@link ScalarProvider} list: instances providing scalar implementations
+ * </ul>
+ */
+@Factory
+public class GraphQLSchemaFactory {
+
+  private static final String SCHEMA_TYPE_QUERY = "Query";
+  private static final String SCHEMA_TYPE_MUTATION = "Mutation";
+
+  /**
+   * Creates an instance of type {@link GraphQLSchema}
+   *
+   * @param registry an instance of type {@link TypeDefinitionRegistry}
+   * @param queryProviders a list of {@link QueryProvider}
+   * @param mutationProviders a list of {@link MutationProvider}
+   * @param typeProviders a list of {@link TypeProvider}
+   * @param scalarProviders a list of {@link ScalarProvider}
+   * @return an instance of type {@link GraphQLSchema}
+   */
+  @Bean
+  @Singleton
+  public GraphQLSchema getSchema(
+      TypeDefinitionRegistry registry,
+      List<QueryProvider> queryProviders,
+      List<MutationProvider> mutationProviders,
+      List<TypeProvider> typeProviders,
+      List<ScalarProvider> scalarProviders) {
+
+    // Loading QUERIES and MUTATIONS
+    var wiringBuilder =
+        RuntimeWiring.newRuntimeWiring()
+            .type(SCHEMA_TYPE_QUERY, process(queryProviders, QueryProvider::getQueries))
+            .type(SCHEMA_TYPE_MUTATION, process(mutationProviders, MutationProvider::getMutations));
+
+    // Loading custom TYPES and SCALARS
+    var processTypes = process(typeProviders, TypeProvider::getTypes);
+    var processScalars = process(scalarProviders, ScalarProvider::getScalars);
+    var wiring = processTypes.andThen(processScalars).apply(wiringBuilder).build();
+
+    // Building the Schema
+    return new SchemaGenerator().makeExecutableSchema(registry, wiring);
+  }
+
+  private static <A, B> UnaryOperator<B> process(
+      List<A> providers, Function<A, UnaryOperator<B>> mapper) {
+    return providers.stream()
+        .map(mapper)
+        .filter(Objects::nonNull)
+        .reduce((left, right) -> (b) -> left.apply(right.apply(b)))
+        .orElse((b) -> b);
+  }
+}

--- a/src/main/java/dwbh/api/graphql/MutationProvider.java
+++ b/src/main/java/dwbh/api/graphql/MutationProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.graphql;
+
+import graphql.schema.idl.TypeRuntimeWiring;
+import java.util.function.UnaryOperator;
+
+/**
+ * A class implementing this interface it's supposed to provide data fetchers to handle mutation
+ * calls
+ */
+@FunctionalInterface
+public interface MutationProvider {
+
+  /**
+   * It should return a function that will receive a {@link TypeRuntimeWiring.Builder} and will
+   * return that same {@link TypeRuntimeWiring.Builder}. The builder received by that function could
+   * be use to chain several {@link TypeRuntimeWiring.Builder#dataFetcher(String,
+   * graphql.schema.DataFetcher)} calls to register mutation fetchers
+   *
+   * @return a function that will receive a {@link TypeRuntimeWiring.Builder} and will return that
+   *     same {@link TypeRuntimeWiring.Builder}
+   */
+  UnaryOperator<TypeRuntimeWiring.Builder> getMutations();
+}

--- a/src/main/java/dwbh/api/graphql/QueryProvider.java
+++ b/src/main/java/dwbh/api/graphql/QueryProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.graphql;
+
+import graphql.schema.idl.TypeRuntimeWiring;
+import java.util.function.UnaryOperator;
+
+/**
+ * A class implementing this interface it's supposed to provide data fetchers to handle query calls
+ */
+@FunctionalInterface
+public interface QueryProvider {
+
+  /**
+   * It should return a function that will receive a {@link TypeRuntimeWiring.Builder} and will
+   * return that same {@link TypeRuntimeWiring.Builder}. The builder received by that function could
+   * be use to chain several {@link TypeRuntimeWiring.Builder#dataFetcher(String,
+   * graphql.schema.DataFetcher)} calls to register query fetchers
+   *
+   * @return a function that will receive a {@link TypeRuntimeWiring.Builder} and will return that
+   *     same {@link TypeRuntimeWiring.Builder}
+   */
+  UnaryOperator<TypeRuntimeWiring.Builder> getQueries();
+}

--- a/src/main/java/dwbh/api/graphql/ScalarProvider.java
+++ b/src/main/java/dwbh/api/graphql/ScalarProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.graphql;
+
+import graphql.schema.idl.RuntimeWiring;
+import java.util.function.UnaryOperator;
+
+/**
+ * A class implementing this interface it's supposed to provide implementation for scalar types
+ * defined in the schema
+ */
+@FunctionalInterface
+public interface ScalarProvider {
+
+  /**
+   * Returns a function that receives a {@link RuntimeWiring.Builder} and returns a {@link
+   * RuntimeWiring.Builder}
+   *
+   * @return a {@link UnaryOperator} of type {@link RuntimeWiring.Builder}
+   */
+  UnaryOperator<RuntimeWiring.Builder> getScalars();
+}

--- a/src/main/java/dwbh/api/graphql/TypeDefinitionRegistryFactory.java
+++ b/src/main/java/dwbh/api/graphql/TypeDefinitionRegistryFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.graphql;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.core.io.ResourceResolver;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import javax.inject.Singleton;
+
+/**
+ * Factory to creates an instance of type {@link TypeDefinitionRegistry}
+ *
+ * @see TypeDefinitionRegistry
+ */
+@Factory
+public class TypeDefinitionRegistryFactory {
+
+  /**
+   * Creates an instance of type {@link TypeDefinitionRegistry}
+   *
+   * @param path where is located the schema
+   * @param resourceResolver required to know how to resolve the path
+   * @return an instance of type {@link TypeDefinitionRegistry}
+   */
+  @Bean
+  @Singleton
+  public TypeDefinitionRegistry load(
+      @Value("${graphql.schema}") String path, ResourceResolver resourceResolver) {
+    var typeRegistry = new TypeDefinitionRegistry();
+    var schemaParser = new SchemaParser();
+    var schemaReader =
+        resourceResolver
+            .getResourceAsStream(path)
+            .map(inputStream -> new InputStreamReader(inputStream, UTF_8))
+            .map(BufferedReader::new);
+
+    return schemaReader.map(schemaParser::parse).map(typeRegistry::merge).orElse(null);
+  }
+}

--- a/src/main/java/dwbh/api/graphql/TypeProvider.java
+++ b/src/main/java/dwbh/api/graphql/TypeProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.graphql;
+
+import graphql.schema.idl.RuntimeWiring;
+import java.util.function.UnaryOperator;
+
+/**
+ * A class implementing this interface it's supposed to provide implementation for type's fields
+ * fetchers defined in the schema
+ */
+@FunctionalInterface
+public interface TypeProvider {
+
+  /**
+   * Returns a function
+   *
+   * @return an {@link UnaryOperator} of type {@link RuntimeWiring.Builder}
+   */
+  UnaryOperator<RuntimeWiring.Builder> getTypes();
+}

--- a/src/main/java/dwbh/api/graphql/providers/CommonScalarProvider.java
+++ b/src/main/java/dwbh/api/graphql/providers/CommonScalarProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.graphql.providers;
+
+import dwbh.api.graphql.ScalarProvider;
+import dwbh.api.graphql.scalars.ScalarsConstants;
+import graphql.schema.idl.RuntimeWiring;
+import java.util.function.UnaryOperator;
+import javax.inject.Singleton;
+
+/**
+ * Contains the implementation of custom scalars used in the schema
+ *
+ * @see ScalarsConstants
+ */
+@Singleton
+public class CommonScalarProvider implements ScalarProvider {
+  @Override
+  public UnaryOperator<RuntimeWiring.Builder> getScalars() {
+    return (builder) ->
+        builder
+            .scalar(ScalarsConstants.ID)
+            .scalar(ScalarsConstants.DATE)
+            .scalar(ScalarsConstants.TIME)
+            .scalar(ScalarsConstants.DATE_TIME)
+            .scalar(ScalarsConstants.DAY_OF_WEEK);
+  }
+}

--- a/src/main/java/dwbh/api/graphql/providers/GroupProvider.java
+++ b/src/main/java/dwbh/api/graphql/providers/GroupProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.graphql.providers;
+
+import dwbh.api.graphql.MutationProvider;
+import dwbh.api.graphql.QueryProvider;
+import dwbh.api.graphql.fetchers.GroupFetcher;
+import dwbh.api.graphql.fetchers.UserGroupFetcher;
+import graphql.schema.idl.TypeRuntimeWiring;
+import java.util.function.UnaryOperator;
+import javax.inject.Singleton;
+
+/**
+ * Contains all mapped fetchers for queries, and mutations for group related operations
+ *
+ * @see QueryProvider
+ * @see MutationProvider
+ */
+@Singleton
+public class GroupProvider implements QueryProvider, MutationProvider {
+
+  private final transient GroupFetcher groupFetcher;
+  private final transient UserGroupFetcher userGroupFetcher;
+
+  /**
+   * Data fetchers required some dependencies
+   *
+   * @param groupFetcher all group fetchers
+   * @param userGroupFetcher all group/user fetchers
+   */
+  public GroupProvider(GroupFetcher groupFetcher, UserGroupFetcher userGroupFetcher) {
+    this.groupFetcher = groupFetcher;
+    this.userGroupFetcher = userGroupFetcher;
+  }
+
+  @Override
+  public UnaryOperator<TypeRuntimeWiring.Builder> getMutations() {
+    return (builder) ->
+        builder
+            .dataFetcher("createGroup", groupFetcher::createGroup)
+            .dataFetcher("updateGroup", groupFetcher::updateGroup)
+            .dataFetcher("addUserToGroup", userGroupFetcher::addUserToGroup)
+            .dataFetcher("leaveGroup", userGroupFetcher::leaveGroup);
+  }
+
+  @Override
+  public UnaryOperator<TypeRuntimeWiring.Builder> getQueries() {
+    return (builder) ->
+        builder
+            .dataFetcher("listGroups", groupFetcher::listGroups)
+            .dataFetcher("listMyGroups", groupFetcher::listMyGroups)
+            .dataFetcher("getGroup", groupFetcher::getGroup);
+  }
+}

--- a/src/main/java/dwbh/api/graphql/providers/GroupTypeProvider.java
+++ b/src/main/java/dwbh/api/graphql/providers/GroupTypeProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.graphql.providers;
+
+import dwbh.api.graphql.TypeProvider;
+import dwbh.api.graphql.fetchers.UserGroupFetcher;
+import dwbh.api.graphql.fetchers.VotingFetcher;
+import graphql.schema.idl.RuntimeWiring;
+import java.util.function.UnaryOperator;
+import javax.inject.Singleton;
+
+/**
+ * Contains all mapped fetchers for for group related types
+ *
+ * @see TypeProvider
+ */
+@Singleton
+public class GroupTypeProvider implements TypeProvider {
+
+  private final transient UserGroupFetcher userGroupFetcher;
+  private final transient VotingFetcher votingFetcher;
+
+  /**
+   * Initializes provider with its dependencies
+   *
+   * @param userGroupFetcher user/group related data fetchers
+   * @param votingFetcher voting related fetchers
+   */
+  public GroupTypeProvider(UserGroupFetcher userGroupFetcher, VotingFetcher votingFetcher) {
+    this.userGroupFetcher = userGroupFetcher;
+    this.votingFetcher = votingFetcher;
+  }
+
+  @Override
+  public UnaryOperator<RuntimeWiring.Builder> getTypes() {
+    return (runtime) ->
+        runtime.type(
+            "Group",
+            builder ->
+                builder
+                    .dataFetcher("members", userGroupFetcher::listUsersGroup)
+                    .dataFetcher("isCurrentUserAdmin", userGroupFetcher::isCurrentUserAdmin)
+                    .dataFetcher("votings", votingFetcher::listVotingsGroup));
+  }
+}

--- a/src/main/java/dwbh/api/graphql/providers/SecurityProvider.java
+++ b/src/main/java/dwbh/api/graphql/providers/SecurityProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.graphql.providers;
+
+import dwbh.api.graphql.MutationProvider;
+import dwbh.api.graphql.QueryProvider;
+import dwbh.api.graphql.fetchers.ResetPasswordFetcher;
+import dwbh.api.graphql.fetchers.SecurityFetcher;
+import graphql.schema.idl.TypeRuntimeWiring;
+import java.util.function.UnaryOperator;
+import javax.inject.Singleton;
+
+/**
+ * Contains all mapped fetchers for queries, and mutations for security related operations
+ *
+ * @see QueryProvider
+ * @see MutationProvider
+ */
+@Singleton
+public class SecurityProvider implements QueryProvider, MutationProvider {
+
+  private final transient SecurityFetcher securityFetcher;
+  private final transient ResetPasswordFetcher resetPasswordFetcher;
+
+  /**
+   * Initializes providers with its dependencies
+   *
+   * @param securityFetcher security related data fetchers
+   * @param resetPasswordFetcher reset password fetcher
+   */
+  public SecurityProvider(
+      SecurityFetcher securityFetcher, ResetPasswordFetcher resetPasswordFetcher) {
+    this.securityFetcher = securityFetcher;
+    this.resetPasswordFetcher = resetPasswordFetcher;
+  }
+
+  @Override
+  public UnaryOperator<TypeRuntimeWiring.Builder> getMutations() {
+    return (builder) ->
+        builder
+            .dataFetcher("resetPassword", resetPasswordFetcher::resetPassword)
+            .dataFetcher("changePassword", securityFetcher::changePassword);
+  }
+
+  @Override
+  public UnaryOperator<TypeRuntimeWiring.Builder> getQueries() {
+    return (builder) ->
+        builder
+            .dataFetcher("login", securityFetcher::loginByCredentials)
+            .dataFetcher("loginOauth2", securityFetcher::loginByOauth2)
+            .dataFetcher("loginOtp", securityFetcher::loginByOtp);
+  }
+}

--- a/src/main/java/dwbh/api/graphql/providers/UserProvider.java
+++ b/src/main/java/dwbh/api/graphql/providers/UserProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.graphql.providers;
+
+import dwbh.api.graphql.MutationProvider;
+import dwbh.api.graphql.QueryProvider;
+import dwbh.api.graphql.TypeProvider;
+import dwbh.api.graphql.fetchers.GroupFetcher;
+import dwbh.api.graphql.fetchers.UserFetcher;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.TypeRuntimeWiring;
+import java.util.function.UnaryOperator;
+import javax.inject.Singleton;
+
+/**
+ * Contains all mapped fetchers for queries, mutations, and types for user related operations
+ *
+ * @see QueryProvider
+ * @see MutationProvider
+ */
+@Singleton
+public class UserProvider implements QueryProvider, MutationProvider, TypeProvider {
+
+  private final transient UserFetcher userFetcher;
+  private final transient GroupFetcher groupFetcher;
+
+  /**
+   * Initializes providers with its required dependencies
+   *
+   * @param userFetcher data fetchers for user operations
+   * @param groupFetcher data fetchers for group operations
+   */
+  public UserProvider(UserFetcher userFetcher, GroupFetcher groupFetcher) {
+    this.userFetcher = userFetcher;
+    this.groupFetcher = groupFetcher;
+  }
+
+  @Override
+  public UnaryOperator<TypeRuntimeWiring.Builder> getMutations() {
+    return null;
+  }
+
+  @Override
+  public UnaryOperator<TypeRuntimeWiring.Builder> getQueries() {
+    return (builder) ->
+        builder
+            .dataFetcher("listUsers", userFetcher::listUsers)
+            .dataFetcher("getUser", userFetcher::getUser)
+            .dataFetcher("myProfile", userFetcher::getCurrentUser);
+  }
+
+  @Override
+  public UnaryOperator<RuntimeWiring.Builder> getTypes() {
+    return (runtime) ->
+        runtime
+            .type("Login", builder -> builder.dataFetcher("profile", userFetcher::getCurrentUser))
+            .type(
+                "UserProfile",
+                builder -> builder.dataFetcher("groups", groupFetcher::listGroupsUser));
+  }
+}

--- a/src/main/java/dwbh/api/graphql/providers/VotingProvider.java
+++ b/src/main/java/dwbh/api/graphql/providers/VotingProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package dwbh.api.graphql.providers;
+
+import dwbh.api.graphql.MutationProvider;
+import dwbh.api.graphql.QueryProvider;
+import dwbh.api.graphql.TypeProvider;
+import dwbh.api.graphql.fetchers.VotingFetcher;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.TypeRuntimeWiring;
+import java.util.function.UnaryOperator;
+import javax.inject.Singleton;
+
+/**
+ * Contains all mapped fetchers for queries, mutations and types for voting related operations
+ *
+ * @see QueryProvider
+ * @see MutationProvider
+ */
+@Singleton
+public class VotingProvider implements QueryProvider, MutationProvider, TypeProvider {
+
+  private final transient VotingFetcher votingFetcher;
+
+  /**
+   * Initializes provider with its dependencies @@param votingFetcher all voting related data
+   * fetchers
+   *
+   * @param votingFetcher {@link VotingFetcher} related voting data fetchers
+   */
+  public VotingProvider(VotingFetcher votingFetcher) {
+    this.votingFetcher = votingFetcher;
+  }
+
+  @Override
+  public UnaryOperator<TypeRuntimeWiring.Builder> getQueries() {
+    return (builder) ->
+        builder
+            .dataFetcher("listUserVotesInGroup", votingFetcher::listUserVotesInGroup)
+            .dataFetcher("getVoting", votingFetcher::getVoting);
+  }
+
+  @Override
+  public UnaryOperator<TypeRuntimeWiring.Builder> getMutations() {
+    return (builder) ->
+        builder
+            .dataFetcher("createVoting", votingFetcher::createVoting)
+            .dataFetcher("createVote", votingFetcher::createVote);
+  }
+
+  @Override
+  public UnaryOperator<RuntimeWiring.Builder> getTypes() {
+    return (runtime) ->
+        runtime
+            .type("Voting", builder -> builder.dataFetcher("votes", votingFetcher::listVotesVoting))
+            .type(
+                "Vote",
+                builder -> builder.dataFetcher("createdBy", votingFetcher::getVoteCreatedBy));
+  }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -50,6 +50,7 @@ flyway:
 graphql:
   enabled: true
   path: /graphql
+  schema: "classpath:graphql/schema.graphqls"
 
 aws:
   credentials:

--- a/src/main/resources/application.yml.template
+++ b/src/main/resources/application.yml.template
@@ -50,6 +50,7 @@ flyway:
 graphql:
   enabled: true
   path: /graphql
+  schema: "classpath:graphql/schema.graphqls"
 
 aws:
   credentials:

--- a/src/test/java/dwbh/api/graphql/AuthenticationCheckTests.java
+++ b/src/test/java/dwbh/api/graphql/AuthenticationCheckTests.java
@@ -95,9 +95,12 @@ public class AuthenticationCheckTests {
                         .dataFetcher("sayHiAuthenticated", (env) -> "Hi authenticated"))
             .build();
     var registry =
-        GraphQLFactory.loadSchema(
-            new ResourceResolver(), "classpath:dwbh/api/graphql/anonymousallowed_schema.graphql");
-    var schema = new SchemaGenerator().makeExecutableSchema(registry.get(), wiring);
+        new TypeDefinitionRegistryFactory()
+            .load(
+                "classpath:dwbh/api/graphql/anonymousallowed_schema.graphql",
+                new ResourceResolver());
+
+    var schema = new SchemaGenerator().makeExecutableSchema(registry, wiring);
 
     // when: executing the query against the GraphQL engine
     return GraphQL.newGraphQL(schema).instrumentation(new AuthenticationCheck()).build();

--- a/src/test/java/dwbh/api/graphql/scalars/DayOfWeekTests.java
+++ b/src/test/java/dwbh/api/graphql/scalars/DayOfWeekTests.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import dwbh.api.graphql.GraphQLFactory;
+import dwbh.api.graphql.TypeDefinitionRegistryFactory;
 import graphql.ExecutionInput;
 import graphql.GraphQL;
 import graphql.GraphQLError;
@@ -167,9 +167,11 @@ public class DayOfWeekTests {
                 builder -> builder.dataFetcher("findDayOfWeek", (env) -> env.getArgument("day")))
             .build();
     var registry =
-        GraphQLFactory.loadSchema(
-            new ResourceResolver(), "classpath:dwbh/api/graphql/scalars/dayofweek_schema.graphql");
-    var schema = new SchemaGenerator().makeExecutableSchema(registry.get(), wiring);
+        new TypeDefinitionRegistryFactory()
+            .load(
+                "classpath:dwbh/api/graphql/scalars/dayofweek_schema.graphql",
+                new ResourceResolver());
+    var schema = new SchemaGenerator().makeExecutableSchema(registry, wiring);
 
     // when: executing the query against the GraphQL engine
     return GraphQL.newGraphQL(schema).build();

--- a/src/test/java/dwbh/api/graphql/scalars/IDTests.java
+++ b/src/test/java/dwbh/api/graphql/scalars/IDTests.java
@@ -19,7 +19,7 @@ package dwbh.api.graphql.scalars;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import dwbh.api.graphql.GraphQLFactory;
+import dwbh.api.graphql.TypeDefinitionRegistryFactory;
 import graphql.ExecutionInput;
 import graphql.GraphQL;
 import graphql.GraphQLError;
@@ -168,9 +168,9 @@ public class IDTests {
                 "Query", builder -> builder.dataFetcher("findById", (env) -> env.getArgument("id")))
             .build();
     var registry =
-        GraphQLFactory.loadSchema(
-            new ResourceResolver(), "classpath:dwbh/api/graphql/scalars/id_schema.graphql");
-    var schema = new SchemaGenerator().makeExecutableSchema(registry.get(), wiring);
+        new TypeDefinitionRegistryFactory()
+            .load("classpath:dwbh/api/graphql/scalars/id_schema.graphql", new ResourceResolver());
+    var schema = new SchemaGenerator().makeExecutableSchema(registry, wiring);
 
     // when: executing the query against the GraphQL engine
     return GraphQL.newGraphQL(schema).build();

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -43,6 +43,7 @@ flyway:
 graphql:
   enabled: true
   path: /graphql
+  schema: "classpath:graphql/schema.graphqls"
 
 duser:
   enabled: false


### PR DESCRIPTION
At the moment all data fetchers are aggregated in the same class. This MR splits up the different data fetchers by domain, so that future refactors by domain will done easier. 