### PR TITLE
feat(back): add an expired check before using a user's otp

### DIFF
--- a/etc/fixtures/load/02-users.sql
+++ b/etc/fixtures/load/02-users.sql
@@ -17,15 +17,15 @@
 --
 
 --password: avengers
-INSERT INTO users (id, name, email, password, otp) VALUES ('d0183ab5-58d9-4e5e-873a-840d6b18f38c','Reed Richards', 'rrichards@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS', '');
-INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea6','Sue Storm', 'sstorm@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS', '');
-INSERT INTO users (id, name, email, password, otp) VALUES ('c2a771bc-f8c5-4112-a440-c80fa4c8e382','Ben Grim', 'bgrim@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS', '');
-INSERT INTO users (id, name, email, password, otp) VALUES ('84d48a35-7659-4710-ad13-4c47785a0e9d','Johnny Storm', 'jstorm@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS', '');
-INSERT INTO users (id, name, email, password, otp) VALUES ('1998c588-d93b-4db6-92e2-a9dbb4cf03b5','Steve Rogers', 'srogers@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS', '');
-INSERT INTO users (id, name, email, password, otp) VALUES ('3465094c-5545-4007-a7bc-da2b1a88d9dc','Tony Stark', 'tstark@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS', '');
-INSERT INTO users (id, name, email, password, otp) VALUES ('06259dfb-8610-40e2-b81c-4f4483fad3dd','Bruce Banner', 'bbanner@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS', '');
-INSERT INTO users (id, name, email, password, otp) VALUES ('9b91a2f5-ff78-451f-be17-3b7360d2fc8b','Donald Blake', 'dblake@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS', '');
-INSERT INTO users (id, name, email, password, otp) VALUES ('a071fa9d-d19f-493b-bb7e-e77aac0eb917','Stephen Strange', 'sstrange@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS', '');
-INSERT INTO users (id, name, email, password, otp) VALUES ('c87f5c9d-0b8c-4673-80bb-600e8c61e33c','Namor McKenzie', 'nmckenzie@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS', '');
-INSERT INTO users (id, name, email, password, otp) VALUES ('e5d0d6c1-1691-4a61-9ccd-99f9c35ab8fb','Charles Xavier', 'cxavier@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS', '');
-INSERT INTO users (id, name, email, password, otp) VALUES ('28f4ead5-0c4f-4f92-bcba-659ce89a61bd','T''Challa', 'tchalla@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS', '');
+INSERT INTO users (id, name, email, password) VALUES ('d0183ab5-58d9-4e5e-873a-840d6b18f38c','Reed Richards', 'rrichards@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS');
+INSERT INTO users (id, name, email, password) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea6','Sue Storm', 'sstorm@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS');
+INSERT INTO users (id, name, email, password) VALUES ('c2a771bc-f8c5-4112-a440-c80fa4c8e382','Ben Grim', 'bgrim@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS');
+INSERT INTO users (id, name, email, password) VALUES ('84d48a35-7659-4710-ad13-4c47785a0e9d','Johnny Storm', 'jstorm@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS');
+INSERT INTO users (id, name, email, password) VALUES ('1998c588-d93b-4db6-92e2-a9dbb4cf03b5','Steve Rogers', 'srogers@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS');
+INSERT INTO users (id, name, email, password) VALUES ('3465094c-5545-4007-a7bc-da2b1a88d9dc','Tony Stark', 'tstark@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS');
+INSERT INTO users (id, name, email, password) VALUES ('06259dfb-8610-40e2-b81c-4f4483fad3dd','Bruce Banner', 'bbanner@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS');
+INSERT INTO users (id, name, email, password) VALUES ('9b91a2f5-ff78-451f-be17-3b7360d2fc8b','Donald Blake', 'dblake@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS');
+INSERT INTO users (id, name, email, password) VALUES ('a071fa9d-d19f-493b-bb7e-e77aac0eb917','Stephen Strange', 'sstrange@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS');
+INSERT INTO users (id, name, email, password) VALUES ('c87f5c9d-0b8c-4673-80bb-600e8c61e33c','Namor McKenzie', 'nmckenzie@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS');
+INSERT INTO users (id, name, email, password) VALUES ('e5d0d6c1-1691-4a61-9ccd-99f9c35ab8fb','Charles Xavier', 'cxavier@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS');
+INSERT INTO users (id, name, email, password) VALUES ('28f4ead5-0c4f-4f92-bcba-659ce89a61bd','T''Challa', 'tchalla@email.com', '$2a$10$OX9LAoZ4QarfDoSgIocrIedyVFfoe9fceI5zAXoYkKjOJV8f15YbS');

--- a/src/main/java/patio/infrastructure/utils/ErrorConstants.java
+++ b/src/main/java/patio/infrastructure/utils/ErrorConstants.java
@@ -132,6 +132,14 @@ public final class ErrorConstants {
   public static final Error BLANK_PASSWORD =
       new Error("API_ERRORS.PASSWORD_IS_BLANK", "The password cannot be left blank");
 
+  /**
+   * Error code used when an otp is expired
+   *
+   * @since 0.1.0
+   */
+  public static final Error OTP_EXPIRED_FOR_USER =
+      new Error("API_ERRORS.OTP_EXPIRED_FOR_USER", "The otp has expired");
+
   private ErrorConstants() {
     /* empty */
   }

--- a/src/main/java/patio/security/services/internal/DefaultResetPasswordService.java
+++ b/src/main/java/patio/security/services/internal/DefaultResetPasswordService.java
@@ -18,6 +18,7 @@
 package patio.security.services.internal;
 
 import io.micronaut.context.annotation.Value;
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -94,6 +95,7 @@ public class DefaultResetPasswordService implements ResetPasswordService {
 
   private void setOTPForUser(String randomToken, User user) {
     user.setOtp(randomToken);
+    user.setOtpCreationDateTime(OffsetDateTime.now());
     userRepository.save(user);
   }
 

--- a/src/main/java/patio/security/services/internal/OtpExpiredForUser.java
+++ b/src/main/java/patio/security/services/internal/OtpExpiredForUser.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of Don't Worry Be Happy (DWBH).
+ * DWBH is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DWBH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+ */
+package patio.security.services.internal;
+
+import static patio.common.domain.utils.Check.checkIsTrue;
+
+import io.micronaut.context.annotation.Value;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import javax.inject.Singleton;
+import patio.common.domain.utils.Check;
+import patio.common.domain.utils.Result;
+import patio.infrastructure.utils.ErrorConstants;
+import patio.user.domain.User;
+
+/**
+ * This checker expects the user's otp has not expired, otherwise it will return a failing {@link
+ * Result}
+ *
+ * @since 0.1.0
+ */
+@Singleton
+public class OtpExpiredForUser {
+
+  private final transient Integer otpExpiryMinutes;
+
+  /**
+   * Initializes the checker with required values from configuration
+   *
+   * @param otpExpiryMinutes minutes taken from configuration
+   */
+  public OtpExpiredForUser(@Value("${otp.expirytime.minutes:none}") Integer otpExpiryMinutes) {
+    this.otpExpiryMinutes = otpExpiryMinutes;
+  }
+
+  /**
+   * Checks the user's opt has not expired. Otherwise will build a failing {@link Result} containing
+   * an error {@link ErrorConstants#OTP_EXPIRED_FOR_USER}
+   *
+   * @param user {@link User} to check her otp code for
+   * @return a failing {@link Result} if the user's otp has expired
+   * @since 0.1.0
+   */
+  public Check check(Optional<User> user) {
+    var operationDate = OffsetDateTime.now();
+    boolean hasExpired =
+        user.map(User::getOtpCreationDateTime)
+            .map(
+                creationDate ->
+                    operationDate.isBefore(creationDate.plusMinutes(this.otpExpiryMinutes)))
+            .orElse(false);
+
+    return checkIsTrue(hasExpired, ErrorConstants.OTP_EXPIRED_FOR_USER);
+  }
+}

--- a/src/main/java/patio/user/domain/User.java
+++ b/src/main/java/patio/user/domain/User.java
@@ -17,9 +17,11 @@
  */
 package patio.user.domain;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -45,6 +47,9 @@ public final class User {
   private String password;
   private String otp;
 
+  @Column(name = "otp_creation_date")
+  private OffsetDateTime otpCreationDateTime;
+
   @OneToMany(mappedBy = "user")
   private Set<UserGroup> groups;
 
@@ -59,39 +64,30 @@ public final class User {
   }
 
   /**
+   * Gets id.
+   *
+   * @return Value of id.
+   */
+  public UUID getId() {
+    return id;
+  }
+
+  /**
+   * Sets new id.
+   *
+   * @param id New value of id.
+   */
+  public void setId(UUID id) {
+    this.id = id;
+  }
+
+  /**
    * Gets name.
    *
    * @return Value of name.
    */
   public String getName() {
     return name;
-  }
-
-  /**
-   * Gets otp.
-   *
-   * @return Value of otp.
-   */
-  public String getOtp() {
-    return otp;
-  }
-
-  /**
-   * Sets new password.
-   *
-   * @param password New value of password.
-   */
-  public void setPassword(String password) {
-    this.password = password;
-  }
-
-  /**
-   * Sets new email.
-   *
-   * @param email New value of email.
-   */
-  public void setEmail(String email) {
-    this.email = email;
   }
 
   /**
@@ -113,12 +109,39 @@ public final class User {
   }
 
   /**
+   * Sets new password.
+   *
+   * @param password New value of password.
+   */
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  /**
    * Gets email.
    *
    * @return Value of email.
    */
   public String getEmail() {
     return email;
+  }
+
+  /**
+   * Sets new email.
+   *
+   * @param email New value of email.
+   */
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  /**
+   * Gets otp.
+   *
+   * @return Value of otp.
+   */
+  public String getOtp() {
+    return otp;
   }
 
   /**
@@ -131,12 +154,39 @@ public final class User {
   }
 
   /**
-   * Gets id.
+   * Gets the time when the otp was created.
    *
-   * @return Value of id.
+   * @return Otp creation time.
    */
-  public UUID getId() {
-    return id;
+  public OffsetDateTime getOtpCreationDateTime() {
+    return otpCreationDateTime;
+  }
+
+  /**
+   * Sets the {@link OffsetDateTime} when the otp is created.
+   *
+   * @param otpCreationDateTime Otp creation time.
+   */
+  public void setOtpCreationDateTime(OffsetDateTime otpCreationDateTime) {
+    this.otpCreationDateTime = otpCreationDateTime;
+  }
+
+  /**
+   * Gets user's groups
+   *
+   * @return set of UserGroups
+   */
+  public Set<UserGroup> getGroups() {
+    return groups;
+  }
+
+  /**
+   * Sets user's groups
+   *
+   * @param groups set of UserGroups the user belongs to
+   */
+  public void setGroups(Set<UserGroup> groups) {
+    this.groups = groups;
   }
 
   /**
@@ -151,22 +201,5 @@ public final class User {
         .map(String::toLowerCase)
         .map(DigestUtils::md5Hex)
         .orElse("");
-  }
-
-  /**
-   * Sets new id.
-   *
-   * @param id New value of id.
-   */
-  public void setId(UUID id) {
-    this.id = id;
-  }
-
-  public Set<UserGroup> getGroups() {
-    return groups;
-  }
-
-  public void setGroups(Set<UserGroup> groups) {
-    this.groups = groups;
   }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -69,6 +69,10 @@ crypto:
     algorithm: ${DWBH_JWT_ALGO}
     issuer: ${DWBH_JWT_ISSUER}
 
+otp:
+  expirytime:
+    minutes: 3
+
 oauth2:
   apikey: ${DWBH_OAUTH2_KEY}
   apisecret: ${DWBH_OAUTH2_SECRET}

--- a/src/main/resources/application.yml.template
+++ b/src/main/resources/application.yml.template
@@ -68,6 +68,10 @@ crypto:
     algorithm: HS256
     issuer: http://localhost:8000/auth/realms/dwbh
 
+otp:
+  expirytime:
+    minutes: 3
+
 oauth2:
   apikey: oauth2apikey
   apisecret: oauth2apisecret

--- a/src/main/resources/migrations/V4__add_otp_creation_date_to_users.sql
+++ b/src/main/resources/migrations/V4__add_otp_creation_date_to_users.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright (C) 2019 Kaleidos Open Source SL
+--
+-- This file is part of Don't Worry Be Happy (DWBH).
+-- DWBH is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- DWBH is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+--
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS otp_creation_date timestamp with time zone NULL;


### PR DESCRIPTION
https://tree.taiga.io/project/pabloruiz-kaleidos-patio/task/134

![Alt Text](https://media.giphy.com/media/xT5LMSQkGkflW3kB9K/giphy.gif)

Validation tests

- [x]  Review the code
- [x] Clean the database fixtures
- [x] Load the database fixtures
- [x] Check a new column exists on database ('users.otp_creation_date' - with no values)
- [x] Reset the password for user1 and click on the link received by email. 
Both user1.otp and user1.otp_creation_date should have values now
- [x] Change the password to a new valid one.
Both user1.otp and user1.otp_creation_date should have been deleted after the password change
- [x] Repeat the same previous resetting process, but STANDING BY FOR AT LEAST 3 MINUTES before clicking the received link to update the password.
- [x] The operation should fail with an error ('API_ERRORS.OTP_EXPIRED_FOR_USER')
