### PR TITLE
feat(back): migrate_voting_average_to_float

### DIFF
--- a/src/main/java/patio/voting/domain/Voting.java
+++ b/src/main/java/patio/voting/domain/Voting.java
@@ -59,7 +59,7 @@ public final class Voting {
   @OneToMany(mappedBy = "voting")
   private List<Vote> votes;
 
-  private Integer average;
+  private Float average;
 
   /**
    * Creates a new fluent builder to build instances of type {@link Voting}
@@ -157,7 +157,7 @@ public final class Voting {
    * @return the voting's average
    * @since 0.1.0
    */
-  public Integer getAverage() {
+  public Float getAverage() {
     return average;
   }
 
@@ -167,7 +167,7 @@ public final class Voting {
    * @param average the voting average
    * @since 0.1.0
    */
-  public void setAverage(Integer average) {
+  public void setAverage(Float average) {
     this.average = average;
   }
 

--- a/src/main/java/patio/voting/repositories/VoteRepository.java
+++ b/src/main/java/patio/voting/repositories/VoteRepository.java
@@ -37,7 +37,7 @@ public interface VoteRepository extends PageableRepository<Vote, UUID> {
    * @param voting the voting this vote belongs to
    * @return the avg score value
    */
-  Integer findAvgScoreByVoting(Voting voting);
+  Float findAvgScoreByVoting(Voting voting);
 
   /**
    * Finds a vote created by some {@link User} in some {@link Voting}

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -54,7 +54,7 @@ type Voting {
     group: Group,
     createdAtDateTime: DateTime
     createdBy: User
-    average: Int
+    average: Float
     votes: [Vote]
 }
 

--- a/src/main/resources/migrations/V5__voting_average_to_float.sql
+++ b/src/main/resources/migrations/V5__voting_average_to_float.sql
@@ -1,0 +1,29 @@
+--
+-- Copyright (C) 2019 Kaleidos Open Source SL
+--
+-- This file is part of Don't Worry Be Happy (DWBH).
+-- DWBH is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- DWBH is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+--
+
+ALTER TABLE voting ALTER COLUMN average type DECIMAL(10,2);
+
+UPDATE voting
+SET average = subquery.average
+FROM (
+  SELECT AVG(vote.score) AS average, voting.id AS voting_id
+  FROM vote, voting
+  WHERE voting.id = vote.voting_id
+  GROUP BY voting.id
+) AS subquery
+WHERE subquery.voting_id = id;


### PR DESCRIPTION
https://tree.taiga.io/project/pabloruiz-kaleidos-patio/issue/140

![GitHub Logo](https://media.giphy.com/media/yxOvhNXbBx971HxDtN/giphy.gif)

Validación

- [x] Revisar el código
- [x] Migraciones. Borrar, crear fixtures y arrancar la aplicación.
En base de datos el campo `voting.average` debería haber cambiado a float, y las medias existentes deberían haberse recalculado a decimales
- [x] Nuevas votaciones. Desde front realizar dos votaciones con dos usuarios de un mismo grupo y confirmar que las nuevas votaciones también tienen precisión decimal (Votos 1+4 => average 2.5)
