### PR TITLE
feat(back): add hue mood when voting

### DIFF
--- a/src/main/java/patio/voting/domain/Vote.java
+++ b/src/main/java/patio/voting/domain/Vote.java
@@ -53,6 +53,9 @@ public final class Vote {
   @Column(name = "created_at")
   private OffsetDateTime createdAtDateTime;
 
+  @Column(name = "hue_mood")
+  private String hueMood;
+
   private String comment;
   private Integer score;
 
@@ -144,6 +147,26 @@ public final class Vote {
    */
   public void setCreatedAtDateTime(OffsetDateTime createdAtDateTime) {
     this.createdAtDateTime = createdAtDateTime;
+  }
+
+  /**
+   * Returns any hue mood the user wanted to add about the vote
+   *
+   * @return a simple {@link String} with the comment
+   * @since 0.1.0
+   */
+  public String getHueMood() {
+    return hueMood;
+  }
+
+  /**
+   * Sets any extra hue mood the user may want to add
+   *
+   * @param hueMood a string with any comment
+   * @since 0.1.0
+   */
+  public void setHueMood(String hueMood) {
+    this.hueMood = hueMood;
   }
 
   /**

--- a/src/main/java/patio/voting/graphql/CreateVoteInput.java
+++ b/src/main/java/patio/voting/graphql/CreateVoteInput.java
@@ -27,14 +27,21 @@ import java.util.UUID;
 public class CreateVoteInput {
   private final transient UUID userId;
   private final transient UUID votingId;
+  private final transient String hueMood;
   private final transient String comment;
   private final transient Integer score;
   private final transient boolean anonymous;
 
   private CreateVoteInput(
-      UUID userId, UUID votingId, String comment, Integer score, boolean anonymous) {
+      UUID userId,
+      UUID votingId,
+      String hueMood,
+      String comment,
+      Integer score,
+      boolean anonymous) {
     this.userId = userId;
     this.votingId = votingId;
+    this.hueMood = hueMood;
     this.comment = comment;
     this.score = score;
     this.anonymous = anonymous;
@@ -68,6 +75,16 @@ public class CreateVoteInput {
    */
   public UUID getVotingId() {
     return votingId;
+  }
+
+  /**
+   * Returns the vote's hue mood if the user added it
+   *
+   * @return the vote's hue mood if any
+   * @since 0.1.0
+   */
+  public String getHueMood() {
+    return hueMood;
   }
 
   /**
@@ -107,7 +124,8 @@ public class CreateVoteInput {
    */
   public static class Builder {
 
-    private transient CreateVoteInput input = new CreateVoteInput(null, null, null, null, false);
+    private transient CreateVoteInput input =
+        new CreateVoteInput(null, null, null, null, null, false);
 
     private Builder() {
       /* empty */
@@ -125,6 +143,7 @@ public class CreateVoteInput {
           new CreateVoteInput(
               userId,
               input.getVotingId(),
+              input.getHueMood(),
               input.getComment(),
               input.getScore(),
               input.isAnonymous());
@@ -143,6 +162,25 @@ public class CreateVoteInput {
           new CreateVoteInput(
               input.getUserId(),
               votingId,
+              input.getHueMood(),
+              input.getComment(),
+              input.getScore(),
+              input.isAnonymous());
+      return this;
+    }
+    /**
+     * Adds a hueMood to the vote
+     *
+     * @param hueMood extra comment to the user's vote
+     * @return current builder instance
+     * @since 0.1.0
+     */
+    public Builder withHueMood(String hueMood) {
+      this.input =
+          new CreateVoteInput(
+              input.getUserId(),
+              input.getVotingId(),
+              hueMood,
               input.getComment(),
               input.getScore(),
               input.isAnonymous());
@@ -161,6 +199,7 @@ public class CreateVoteInput {
           new CreateVoteInput(
               input.getUserId(),
               input.getVotingId(),
+              input.getHueMood(),
               comment,
               input.getScore(),
               input.isAnonymous());
@@ -179,6 +218,7 @@ public class CreateVoteInput {
           new CreateVoteInput(
               input.getUserId(),
               input.getVotingId(),
+              input.getHueMood(),
               input.getComment(),
               score,
               input.isAnonymous());
@@ -197,6 +237,7 @@ public class CreateVoteInput {
           new CreateVoteInput(
               input.getUserId(),
               input.getVotingId(),
+              input.getHueMood(),
               input.getComment(),
               input.getScore(),
               anonymous);

--- a/src/main/java/patio/voting/graphql/VotingFetcherUtils.java
+++ b/src/main/java/patio/voting/graphql/VotingFetcherUtils.java
@@ -63,6 +63,7 @@ final class VotingFetcherUtils {
     Context ctx = environment.getContext();
     User user = ctx.getAuthenticatedUser();
     UUID votingId = environment.getArgument("votingId");
+    String hueMood = environment.getArgument("hueMood");
     String comment = environment.getArgument("comment");
     Integer score = environment.getArgument("score");
     boolean anonymous = environment.getArgument("anonymous");
@@ -70,6 +71,7 @@ final class VotingFetcherUtils {
     return CreateVoteInput.newBuilder()
         .withUserId(user.getId())
         .withVotingId(votingId)
+        .withHueMood(hueMood)
         .withComment(comment)
         .withScore(score)
         .withAnonymous(anonymous)

--- a/src/main/java/patio/voting/services/internal/DefaultVotingService.java
+++ b/src/main/java/patio/voting/services/internal/DefaultVotingService.java
@@ -148,6 +148,7 @@ public class DefaultVotingService implements VotingService {
                         .with(v -> v.setVoting(slot))
                         .with(v -> v.setCreatedBy(user.orElse(null)))
                         .with(v -> v.setComment(input.getComment()))
+                        .with(v -> v.setHueMood(input.getHueMood()))
                         .with(v -> v.setScore(input.getScore()))
                         .build())
             .map(voteRepository::save)

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -65,6 +65,7 @@ type Vote {
     voting: Voting
     createdAtDateTime: DateTime
     createdBy: User
+    hueMood: String
 }
 
 type Tokens {
@@ -120,7 +121,7 @@ type Mutation {
     createVoting(groupId: ID): Voting
 
     # creates a user vote
-    createVote(votingId: ID!, score: Int!, comment: String, anonymous: Boolean = false): Vote
+    createVote(votingId: ID!, score: Int!, hueMood: String, comment: String, anonymous: Boolean = false): Vote
 
     # creates a group
     createGroup(name: String!, visibleMemberList: Boolean!, anonymousVote: Boolean!, votingTime: Time!, votingDays: [DayOfWeek]!): Group

--- a/src/main/resources/migrations/V6__add_hue_mood_to_vote.sql
+++ b/src/main/resources/migrations/V6__add_hue_mood_to_vote.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright (C) 2019 Kaleidos Open Source SL
+--
+-- This file is part of Don't Worry Be Happy (DWBH).
+-- DWBH is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- DWBH is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+--
+
+ALTER TABLE vote ADD COLUMN IF NOT EXISTS hue_mood VARCHAR (200) NULL;

--- a/src/test/java/patio/voting/services/VotingServiceTests.java
+++ b/src/test/java/patio/voting/services/VotingServiceTests.java
@@ -18,9 +18,14 @@
 package patio.voting.services;
 
 import static io.github.benas.randombeans.api.EnhancedRandom.random;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
@@ -118,6 +123,8 @@ public class VotingServiceTests {
         CreateVoteInput.newBuilder()
             .withUserId(user.getId())
             .withVotingId(voting.getId())
+            .withHueMood("COVID 19")
+            .withComment("The worst day ever")
             .withScore(1)
             .withAnonymous(false)
             .build();


### PR DESCRIPTION
https://tree.taiga.io/project/pabloruiz-kaleidos-patio/task/159

![gif](https://media.giphy.com/media/QAtOFlW4N2PUdTjVnH/giphy.gif)

Validation tests
- [ ] Create a vote for a user including her hue mood
- [ ] Get the votes for that user validating it's shown the previous hue mood

```graphql
  mutation {
  	createVote(
      votingId: "ffad4562-4971-11e9-98cd-d663bd873d93",
      score: 5,
      hueMood: "I'm ok",
      comment: "My comment",
      anonymous: false) {
      voting {
        id,
        votes {
          id
        }
      }
    }
```
```graphql
query {    
  listUserVotesInGroup(
    userId: "3465094c-5545-4007-a7bc-da2b1a88d9dc", 
    groupId: "dedc6675-ab79-495e-9245-1fc20545eb83", 
    startDateTime:"2020-06-07T00:00:00Z", 
    endDateTime:"2020-06-09T00:00:00Z") {
    id,
    score,
    hueMood,
    createdAtDateTime
  }
}
```
