### PR TITLE
add two new migrations fixing and populating moving_averages

### DIFF
--- a/src/main/resources/migrations/V8__fix_created_at_data_from_voting_stats.sql
+++ b/src/main/resources/migrations/V8__fix_created_at_data_from_voting_stats.sql
@@ -1,0 +1,40 @@
+--
+-- Copyright (C) 2019 Kaleidos Open Source SL
+--
+-- This file is part of Don't Worry Be Happy (DWBH).
+-- DWBH is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- DWBH is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+--
+
+--  Populates `create_at` field from voting_stats, taking the last vote from each `voting`
+
+UPDATE
+  voting_stats
+SET
+  created_at = x.created_at
+FROM
+  (
+    SELECT
+      vs.id AS id,
+      MAX(vo.created_at) AS created_at
+    FROM
+      voting v
+      JOIN voting_stats vs ON
+          vs.voting_id = v.id
+      JOIN vote vo ON
+          vo.voting_id = v.id
+    GROUP BY
+      vs.id
+  ) x
+WHERE
+  voting_stats.id = x.id

--- a/src/main/resources/migrations/V9__calculates_moving_averages.sql
+++ b/src/main/resources/migrations/V9__calculates_moving_averages.sql
@@ -1,0 +1,50 @@
+--
+-- Copyright (C) 2019 Kaleidos Open Source SL
+--
+-- This file is part of Don't Worry Be Happy (DWBH).
+-- DWBH is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- DWBH is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with DWBH.  If not, see <https://www.gnu.org/licenses/>
+--
+
+--  Populates `moving_average` field from `voting_stats` calculating the data from its `voting` data
+
+DO $$
+DECLARE
+    gid uuid;
+BEGIN
+    FOR gid IN SELECT * FROM "groups" LOOP
+      update
+          voting_stats
+      set
+        moving_average = subquery.moving_average_60
+      from
+        (
+        select
+            vs.id as voting_stats_id,
+            average,
+            avg(vs.average) over(
+            order by vs.created_at rows between 59 preceding and current row) as moving_average_60
+        from
+            voting_stats vs
+        join voting v on
+            vs.voting_id = v.id
+        join "groups" g on
+            v.group_id = g.id
+        where
+            vs.average is not null
+            and voting_id in (select id from voting where group_id = gid)
+          ) subquery
+      where
+        id = subquery.voting_stats_id;
+    END LOOP;
+END $$;


### PR DESCRIPTION
**Changes**

Migration v8: populates `create_at` field from voting_stats, taking the last vote from each `voting`
Migration v9: Populates `moving_average` field from `voting_stats` calculating the data from its `voting` data

- Moving averages should take into accounts just the 60 previous days to each voting, omitting null values 

https://tree.taiga.io/project/pabloruiz-kaleidos-patio/task/279?kanban-status=1813386

**Validation tests**

- [ ] Load the Kaleidos's dump and start the application.
- It should fix created_at data field, and populate moving_averages from voting_stats with legacy stats. Verify the data consistency
- [ ] Drop database, change it to develop, start & load fixtures, came back again to this branch and start with the outdated db
- It should fix created_at data field and populate moving_averages from voting_stats with legacy stats. Verify the data consistency
- [ ] Drop database and start the application without loading fixtures
- The database should be empty but with the proper model
- [ ] Move task #279 to Ready For Tests in Taiga

NOTE: If you run and load fixtures from scratch, the moving average field will remain empty as its migration has already been executed when the data is loaded. It's a matter of the fixtures to populate that field with new data.