### PR TITLE
refactor the stats query to get the results paginated and not by dates

### DIFF
--- a/src/main/java/patio/voting/graphql/GetStatsByGroupInput.java
+++ b/src/main/java/patio/voting/graphql/GetStatsByGroupInput.java
@@ -17,7 +17,6 @@
  */
 package patio.voting.graphql;
 
-import java.time.OffsetDateTime;
 import java.util.UUID;
 import patio.common.domain.utils.Builder;
 
@@ -28,8 +27,6 @@ import patio.common.domain.utils.Builder;
  */
 public class GetStatsByGroupInput {
 
-  private OffsetDateTime startDateTime;
-  private OffsetDateTime endDateTime;
   private UUID groupId;
 
   /**
@@ -40,44 +37,6 @@ public class GetStatsByGroupInput {
    */
   public static Builder<GetStatsByGroupInput> newBuilder() {
     return Builder.build(GetStatsByGroupInput::new);
-  }
-
-  /**
-   * Returns the startDate
-   *
-   * @return the startDate
-   * @since 0.1.0
-   */
-  public OffsetDateTime getStartDateTime() {
-    return startDateTime;
-  }
-
-  /**
-   * Sets the startDateTime
-   *
-   * @param startDateTime the first date time to retrieve the stats
-   */
-  public void setStartDateTime(OffsetDateTime startDateTime) {
-    this.startDateTime = startDateTime;
-  }
-
-  /**
-   * Returns the endDate
-   *
-   * @return the endDate
-   * @since 0.1.0
-   */
-  public OffsetDateTime getEndDateTime() {
-    return endDateTime;
-  }
-
-  /**
-   * Sets the endDateTime
-   *
-   * @param endDateTime the last date time to retrieve the stats
-   */
-  public void setEndDateTime(OffsetDateTime endDateTime) {
-    this.endDateTime = endDateTime;
   }
 
   /**

--- a/src/main/java/patio/voting/graphql/VotingStatsFetcher.java
+++ b/src/main/java/patio/voting/graphql/VotingStatsFetcher.java
@@ -17,16 +17,16 @@
  */
 package patio.voting.graphql;
 
+import static patio.common.graphql.ArgumentUtils.extractPaginationFrom;
+
 import graphql.schema.DataFetchingEnvironment;
-import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.UUID;
 import javax.inject.Singleton;
+import patio.common.domain.utils.PaginationRequest;
 import patio.common.domain.utils.PaginationResult;
 import patio.group.domain.Group;
 import patio.voting.domain.Vote;
-import patio.voting.domain.Voting;
 import patio.voting.domain.VotingStats;
+import patio.voting.services.VotingStatsService;
 
 /**
  * All related GraphQL operations over the {@link Group} domain
@@ -35,6 +35,24 @@ import patio.voting.domain.VotingStats;
  */
 @Singleton
 public class VotingStatsFetcher {
+
+  /**
+   * Instance handling the business logic
+   *
+   * @since 0.1.0
+   */
+  private final transient VotingStatsService service;
+
+  /**
+   * Constructor initializing the access to the business logic
+   *
+   * @param service class handling the logic over groups
+   * @since 0.1.0
+   */
+  public VotingStatsFetcher(VotingStatsService service) {
+    this.service = service;
+  }
+
   /**
    * Fetches the voting statistics for a group between a time interval
    *
@@ -42,22 +60,10 @@ public class VotingStatsFetcher {
    * @return a list of available {@link Vote}
    * @since 0.1.0
    */
-  // TODO: Implementation pending!!
   public PaginationResult<VotingStats> getVotingStatsByGroup(DataFetchingEnvironment env) {
-    var votingMap = Voting.newBuilder().with(v -> v.setId(UUID.randomUUID())).build();
-    var votingStat =
-        VotingStats.newBuilder()
-            .with(vs -> vs.setMovingAverage(3.7d))
-            .with(vs -> vs.setAverage(1.7d))
-            .with(vs -> vs.setCreatedAtDateTime(OffsetDateTime.now()))
-            .with(vs -> vs.setVoting(votingMap))
-            .build();
+    GetStatsByGroupInput input = VotingStatsFetcherUtils.createGetStatsByGroupInput(env);
+    PaginationRequest pagination = extractPaginationFrom(env);
 
-    return PaginationResult.newBuilder()
-        .with(pr -> pr.setTotalCount(1))
-        .with(pr -> pr.setLastPage(0))
-        .with(pr -> pr.setPage(0))
-        .with(pr -> pr.setData(List.of(votingStat)))
-        .build();
+    return service.getVotingStatsByGroup(input, pagination);
   }
 }

--- a/src/main/java/patio/voting/graphql/VotingStatsFetcherUtils.java
+++ b/src/main/java/patio/voting/graphql/VotingStatsFetcherUtils.java
@@ -18,7 +18,6 @@
 package patio.voting.graphql;
 
 import graphql.schema.DataFetchingEnvironment;
-import java.time.OffsetDateTime;
 import java.util.UUID;
 
 /**
@@ -44,13 +43,7 @@ final class VotingStatsFetcherUtils {
   /* default */ static GetStatsByGroupInput createGetStatsByGroupInput(
       DataFetchingEnvironment environment) {
     UUID groupId = environment.getArgument("groupId");
-    OffsetDateTime startDate = environment.getArgument("startDateTime");
-    OffsetDateTime endDate = environment.getArgument("endDateTime");
 
-    return GetStatsByGroupInput.newBuilder()
-        .with(i -> i.setGroupId(groupId))
-        .with(i -> i.setStartDateTime(startDate))
-        .with(i -> i.setEndDateTime(endDate))
-        .build();
+    return GetStatsByGroupInput.newBuilder().with(i -> i.setGroupId(groupId)).build();
   }
 }

--- a/src/main/java/patio/voting/repositories/VotingStatsRepository.java
+++ b/src/main/java/patio/voting/repositories/VotingStatsRepository.java
@@ -53,8 +53,6 @@ public interface VotingStatsRepository extends PageableRepository<VotingStats, U
    * Finds all statistics for a given group between a time interval
    *
    * @param group the id of the group to get its statistics from
-   * @param startDateTime lower bound of type {@link OffsetDateTime}
-   * @param endDateTime upper bound of type {@link OffsetDateTime}
    * @param pageable the information to paginate over the result set
    * @return a paginated result of {@link VotingStats} instances from the given {@link Group}
    */
@@ -63,15 +61,12 @@ public interface VotingStatsRepository extends PageableRepository<VotingStats, U
           "SELECT vs "
               + "FROM Voting v JOIN v.stats vs "
               + "WHERE v.group = :group "
-              + "AND v.createdAtDateTime BETWEEN :startDateTime AND :endDateTime "
               + "AND vs.average is not null "
-              + "ORDER BY vs.createdAtDateTime",
+              + "ORDER BY vs.createdAtDateTime DESC",
       countQuery =
           "SELECT COUNT(vs) "
               + "FROM Voting v JOIN v.stats vs "
               + "WHERE v.group = :group "
-              + "AND v.createdAtDateTime BETWEEN :startDateTime AND :endDateTime "
               + "AND vs.average is not null")
-  Page<VotingStats> findStatsByGroup(
-      Group group, OffsetDateTime startDateTime, OffsetDateTime endDateTime, Pageable pageable);
+  Page<VotingStats> findStatsByGroup(Group group, Pageable pageable);
 }

--- a/src/main/java/patio/voting/services/internal/DefaultVotingStatsService.java
+++ b/src/main/java/patio/voting/services/internal/DefaultVotingStatsService.java
@@ -99,15 +99,11 @@ public class DefaultVotingStatsService implements VotingStatsService {
   public PaginationResult<VotingStats> getVotingStatsByGroup(
       GetStatsByGroupInput input, PaginationRequest pagination) {
     Optional<Group> optionalGroup = groupRepository.findById(input.getGroupId());
-    OffsetDateTime startDateTime = input.getStartDateTime();
-    OffsetDateTime endDateTime = input.getEndDateTime();
     var pageable = Pageable.from(pagination.getPage(), pagination.getMax());
 
     var page =
         optionalGroup
-            .map(
-                group ->
-                    votingStatsRep.findStatsByGroup(group, startDateTime, endDateTime, pageable))
+            .map(group -> votingStatsRep.findStatsByGroup(group, pageable))
             .orElse(Page.empty());
 
     return PaginationResult.from(page);

--- a/src/test/java/patio/infrastructure/graphql/fetchers/VotingStatsFetcherTests.java
+++ b/src/test/java/patio/infrastructure/graphql/fetchers/VotingStatsFetcherTests.java
@@ -17,7 +17,22 @@
  */
 package patio.infrastructure.graphql.fetchers;
 
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import patio.common.domain.utils.PaginationResult;
+import patio.infrastructure.graphql.fetchers.utils.FetcherTestUtils;
+import patio.user.domain.User;
+import patio.voting.domain.VotingStats;
 import patio.voting.graphql.VotingStatsFetcher;
+import patio.voting.services.internal.DefaultVotingStatsService;
 
 /**
  * Tests {@link VotingStatsFetcher} class
@@ -26,45 +41,42 @@ import patio.voting.graphql.VotingStatsFetcher;
  */
 class VotingStatsFetcherTests {
 
-  // TODO: Implementation pending!!
-  /*
-    @Test
-    void testGetVotingStatsByGroup() {
-      // given: a logged user
-      var authenticatedUser = random(User.class);
+  @Test
+  void testGetVotingStatsByGroup() {
+    // given: a logged user
+    var authenticatedUser = random(User.class);
 
-      // and: a data input
-      var groupId = UUID.randomUUID();
-      var startDateTime = random(OffsetDateTime.class);
-      var endDateTime = random(OffsetDateTime.class);
+    // and: a data input
+    var groupId = UUID.randomUUID();
+    var startDateTime = random(OffsetDateTime.class);
+    var endDateTime = random(OffsetDateTime.class);
 
-      // and: mocked service returning the expected result
-      var mockedService = Mockito.mock(DefaultVotingStatsService.class);
-      var partialResult = List.of(random(VotingStats.class), random(VotingStats.class));
-      var paginationResult =
-          PaginationResult.newBuilder()
-              .with(pr -> pr.setData(partialResult))
-              .with(pr -> pr.setTotalCount(partialResult.size()))
-              .build();
-      Mockito.when(mockedService.getVotingStatsByGroup(any(), any())).thenReturn(paginationResult);
+    // and: mocked service returning the expected result
+    var mockedService = Mockito.mock(DefaultVotingStatsService.class);
+    var partialResult = List.of(random(VotingStats.class), random(VotingStats.class));
+    var paginationResult =
+        PaginationResult.newBuilder()
+            .with(pr -> pr.setData(partialResult))
+            .with(pr -> pr.setTotalCount(partialResult.size()))
+            .build();
+    Mockito.when(mockedService.getVotingStatsByGroup(any(), any())).thenReturn(paginationResult);
 
-      // and: mocked environment
-      var arguments = new HashMap<String, Object>();
-      arguments.put("groupId", groupId);
-      arguments.put("startDateTime", startDateTime);
-      arguments.put("endDateTime", endDateTime);
+    // and: mocked environment
+    var arguments = new HashMap<String, Object>();
+    arguments.put("groupId", groupId);
+    arguments.put("startDateTime", startDateTime);
+    arguments.put("endDateTime", endDateTime);
 
-      var mockedEnvironment =
-          FetcherTestUtils.generateMockedEnvironment(authenticatedUser, arguments);
+    var mockedEnvironment =
+        FetcherTestUtils.generateMockedEnvironment(authenticatedUser, arguments);
 
-      // when: invoking the fetcher with correct data
-      VotingStatsFetcher fetcher = new VotingStatsFetcher(mockedService);
-      PaginationResult<VotingStats> paginatedResults =
-          fetcher.getVotingStatsByGroup(mockedEnvironment);
+    // when: invoking the fetcher with correct data
+    VotingStatsFetcher fetcher = new VotingStatsFetcher(mockedService);
+    PaginationResult<VotingStats> paginatedResults =
+        fetcher.getVotingStatsByGroup(mockedEnvironment);
 
-      // then: we should build the expected result
-      assertEquals("Two voting statistics inside!", paginatedResults.getTotalCount(), 2);
-      assertEquals("The result is the expected one!", paginatedResults.getData(), partialResult);
-    }
-  */
+    // then: we should build the expected result
+    assertEquals("Two voting statistics inside!", paginatedResults.getTotalCount(), 2);
+    assertEquals("The result is the expected one!", paginatedResults.getData(), partialResult);
+  }
 }

--- a/src/test/java/patio/voting/repositories/VotingStatsRepositoryTests.java
+++ b/src/test/java/patio/voting/repositories/VotingStatsRepositoryTests.java
@@ -126,70 +126,17 @@ public class VotingStatsRepositoryTests {
     // given: pre-existent data
     fixtures.load(VotingStatsRepositoryTests.class, "testFindMovingAverageByGroup.sql");
 
-    var paginationRequest = PaginationRequest.from(12, 0);
+    var paginationRequest = PaginationRequest.from(2, 0);
     var pageable = Pageable.from(paginationRequest.getPage(), paginationRequest.getMax());
 
     // when: asking to calculate the moving average between two dates that comprise all data
-    OffsetDateTime startDate = OffsetDateTime.parse("2015-01-30T12:00:01+01:00");
-    OffsetDateTime endDate = OffsetDateTime.now();
-
     var statsPage =
         groupRepository
             .findById(UUID.fromString("d64db962-3455-11e9-b210-d663bd873d93"))
-            .map(
-                (group) ->
-                    votingStatsRepository.findStatsByGroup(group, startDate, endDate, pageable))
+            .map((group) -> votingStatsRepository.findStatsByGroup(group, pageable))
             .orElse(Page.empty());
 
     // then: we should get all voting stats
     assertEquals(statsPage.getTotalSize(), 2);
-  }
-
-  @Test
-  void testGetGroupStatsFindOneVotingStats() {
-    // given: pre-existent data
-    fixtures.load(VotingStatsRepositoryTests.class, "testFindMovingAverageByGroup.sql");
-
-    var paginationRequest = PaginationRequest.from(12, 0);
-    var pageable = Pageable.from(paginationRequest.getPage(), paginationRequest.getMax());
-
-    // when: asking to calculate the moving average between two dates that comprise all data
-    OffsetDateTime startDate = OffsetDateTime.parse("2020-06-20T12:12:01+01:00");
-    OffsetDateTime endDate = OffsetDateTime.parse("2020-06-21T12:12:01+01:00");
-
-    var statsPage =
-        groupRepository
-            .findById(UUID.fromString("d64db962-3455-11e9-b210-d663bd873d93"))
-            .map(
-                (group) ->
-                    votingStatsRepository.findStatsByGroup(group, startDate, endDate, pageable))
-            .orElse(Page.empty());
-
-    // then: we should get one voting stat
-    assertEquals(statsPage.getTotalSize(), 1);
-  }
-
-  @Test
-  void testGetGroupStatsFindNoneVotingStats() {
-    // given: pre-existent data
-    fixtures.load(VotingStatsRepositoryTests.class, "testFindMovingAverageByGroup.sql");
-
-    var paginationRequest = PaginationRequest.from(12, 0);
-    var pageable = Pageable.from(paginationRequest.getPage(), paginationRequest.getMax());
-
-    // when: asking to calculate the moving average from a future period
-    OffsetDateTime startDate = OffsetDateTime.parse("2020-06-29T12:00:01+01:00");
-    OffsetDateTime endDate = OffsetDateTime.parse("2020-06-30T12:00:01+01:00");
-
-    var statsPage =
-        groupRepository
-            .findById(UUID.fromString("d64db962-3455-11e9-b210-d663bd873d93"))
-            .map(
-                (group) ->
-                    votingStatsRepository.findStatsByGroup(group, startDate, endDate, pageable))
-            .orElse(Page.empty());
-
-    // then: we should get no voting stat
-    assertEquals(statsPage.getTotalSize(), 0);
   }
 }

--- a/src/test/java/patio/voting/services/VotingStatsServiceTests.java
+++ b/src/test/java/patio/voting/services/VotingStatsServiceTests.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.UUID;
@@ -103,15 +102,8 @@ public class VotingStatsServiceTests {
   void testGetVotingStatsByGroupSuccess() {
     // given: the mocked data input
     var group = Group.builder().with(g -> g.setId(UUID.randomUUID())).build();
-    var startDate = random(OffsetDateTime.class);
-    var endDate = random(OffsetDateTime.class);
     var paginationRequest = PaginationRequest.from(5, 0);
-    var input =
-        GetStatsByGroupInput.newBuilder()
-            .with(i -> i.setGroupId(group.getId()))
-            .with(i -> i.setStartDateTime(startDate))
-            .with(i -> i.setEndDateTime(endDate))
-            .build();
+    var input = GetStatsByGroupInput.newBuilder().with(i -> i.setGroupId(group.getId())).build();
 
     // and: some mocked repositories
     var votingRepository = Mockito.mock(VotingRepository.class);
@@ -129,8 +121,7 @@ public class VotingStatsServiceTests {
 
     // and: the main repository returning the expected when called with the right parameters
     var votingStatRepository = Mockito.mock(VotingStatsRepository.class);
-    when(votingStatRepository.findStatsByGroup(group, startDate, endDate, pageable))
-        .thenReturn(pageResult);
+    when(votingStatRepository.findStatsByGroup(group, pageable)).thenReturn(pageResult);
 
     // when: the service method is executed
     var defaultVotingStatsService =
@@ -142,7 +133,7 @@ public class VotingStatsServiceTests {
     // then: we get the expected results
     assertEquals(paginatedVotingStats.getData(), expectedResults);
     assertEquals(paginatedVotingStats.getTotalCount(), expectedResults.size());
-    verify(votingStatRepository, times(1)).findStatsByGroup(group, startDate, endDate, pageable);
+    verify(votingStatRepository, times(1)).findStatsByGroup(group, pageable);
   }
 
   @Test
@@ -150,17 +141,10 @@ public class VotingStatsServiceTests {
   void testGetVotingStatsByGroupWhenBadGroupId() {
     // given: a wrong data input
     var group = Group.builder().with(g -> g.setId(UUID.randomUUID())).build();
-    var startDate = random(OffsetDateTime.class);
-    var endDate = random(OffsetDateTime.class);
     var paginationRequest = PaginationRequest.from(5, 0);
 
     var wrongGroupId = random(UUID.class);
-    var input =
-        GetStatsByGroupInput.newBuilder()
-            .with(i -> i.setGroupId(wrongGroupId))
-            .with(i -> i.setStartDateTime(startDate))
-            .with(i -> i.setEndDateTime(endDate))
-            .build();
+    var input = GetStatsByGroupInput.newBuilder().with(i -> i.setGroupId(wrongGroupId)).build();
 
     // and: some mocked repositories
     var votingRepository = Mockito.mock(VotingRepository.class);
@@ -178,8 +162,7 @@ public class VotingStatsServiceTests {
 
     // and: the main repository returning what's expected when called with the right parameters
     var votingStatRepository = Mockito.mock(VotingStatsRepository.class);
-    when(votingStatRepository.findStatsByGroup(group, startDate, endDate, pageable))
-        .thenReturn(pageResult);
+    when(votingStatRepository.findStatsByGroup(group, pageable)).thenReturn(pageResult);
 
     // when: the service method is executed with the wrong parameters
     var defaultVotingStatsService =
@@ -192,6 +175,6 @@ public class VotingStatsServiceTests {
     var noResults = new ArrayList<>();
     assertEquals(paginatedVotingStats.getData(), noResults);
     assertEquals(paginatedVotingStats.getTotalCount(), noResults.size());
-    verify(votingStatRepository, times(0)).findStatsByGroup(group, startDate, endDate, pageable);
+    verify(votingStatRepository, times(0)).findStatsByGroup(group, pageable);
   }
 }


### PR DESCRIPTION
**Objective**

Change the way to recover the group's statistics, not by two dates but paginating directly (page/max per page) : Get all the stats for group G starting from now, and according to 5 elements per page, give me the second page.

![gif](https://media1.tenor.com/images/971f729273b07b1e266a4fcd75a78d46/tenor.gif?itemid=12432486)

**Validation Tests**

- [ ] Check the code
- [ ] Run the query `getStatsByGroup` (changing the `max` elements per page and the `page` requested)
- Verify that as you ask for incremental pages, the retrieved stats are older than the previous page.
- Verify the pagination works as expected, retrieving the correct elements, and setting the correct `lastPage` you can ask for.
- [ ] Move Taiga's #282 task to Ready for Test
- [ ] Verify front has already implement these changes before merging

```
query {
  getStatsByGroup(
    groupId: "9667bd4f-e220-442e-ae96-80196722e1cd"
    page: 0
    max: 7
  ) {
    page
    lastPage
    totalCount
    data {
      average,
      movingAverage,
      voting {
        createdAtDateTime
      }
      }
    }
  }
```
