### PR TITLE
Feat task 235 next previous votation API

### DIFF
--- a/src/main/java/patio/voting/graphql/VotingFetcher.java
+++ b/src/main/java/patio/voting/graphql/VotingFetcher.java
@@ -21,6 +21,7 @@ import static patio.common.graphql.ArgumentUtils.extractPaginationFrom;
 
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironment;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -201,5 +202,37 @@ public class VotingFetcher {
     DidIVoteInput input = VotingFetcherUtils.didIVoteInput(env);
 
     return ResultUtils.render(service.didUserVotedInVoting(input.getUser(), input.getVotingId()));
+  }
+
+  /**
+   * Fetches the next {@link Voting} in time
+   *
+   * @param env GraphQL execution environment
+   * @return the next voting
+   * @since 0.1.0
+   */
+  // TODO: Implementation pending!!
+  public Voting getNextVoting(DataFetchingEnvironment env) {
+
+    return Voting.newBuilder()
+        .with(v -> v.setId(UUID.randomUUID()))
+        .with(v -> v.setCreatedAtDateTime(OffsetDateTime.now()))
+        .build();
+  }
+
+  /**
+   * Fetches the next {@link Voting} in time
+   *
+   * @param env GraphQL execution environment
+   * @return the next voting
+   * @since 0.1.0
+   */
+  // TODO: Implementation pending!!
+  public Voting getPreviousVoting(DataFetchingEnvironment env) {
+
+    return Voting.newBuilder()
+        .with(v -> v.setId(UUID.randomUUID()))
+        .with(v -> v.setCreatedAtDateTime(OffsetDateTime.now()))
+        .build();
   }
 }

--- a/src/main/java/patio/voting/graphql/VotingProvider.java
+++ b/src/main/java/patio/voting/graphql/VotingProvider.java
@@ -77,7 +77,9 @@ public class VotingProvider implements QueryProvider, MutationProvider, TypeProv
                     builder
                         .dataFetcher("votes", votingFetcher::listVotesVoting)
                         .dataFetcher("didIVote", votingFetcher::didIVote)
-                        .dataFetcher("stats", votingFetcher::getVotingStats))
+                        .dataFetcher("stats", votingFetcher::getVotingStats)
+                        .dataFetcher("nextVoting", votingFetcher::getNextVoting)
+                        .dataFetcher("previousVoting", votingFetcher::getPreviousVoting))
             .type(
                 "Vote",
                 builder -> builder.dataFetcher("createdBy", votingFetcher::getVoteCreatedBy));

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -65,6 +65,8 @@ type Voting {
     stats: VotingStats
     votes(page: Int, max: Int): VotePaginationResult
     didIVote: Boolean
+    nextVoting: Voting
+    previousVoting: Voting
 }
 
 type VotingStats {


### PR DESCRIPTION
**Objective**

Adds two more fields in the API for Voting response type: nextVoting / previousVoting

![gif](https://media1.tenor.com/images/ea5016f4b06302ed61d8d0d8f4f594d4/tenor.gif?itemid=14320435)

**Validation Tests**

- [x] Validate the api
- [x] Run a query that returns a voting validating it renders data in previous/nextVoting
- [x] Move Taiga's #235 task to Ready for Test

```
  query {
  getVoting(id: "") {
    id,
    createdAtDateTime,
    nextVoting {
    	id,
    	createdAtDateTime,
    }
    previousVoting {
      id,
    	createdAtDateTime,
    }
  }
}
```
