### PR TITLE
feat(group): Add 'votingDuration' field and implement its effects in …

### DIFF
--- a/etc/fixtures/load/01-groups.sql
+++ b/etc/fixtures/load/01-groups.sql
@@ -16,6 +16,6 @@
 -- along with PATIO.  If not, see <https://www.gnu.org/licenses/>
 --
 
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '14:48:12.146512+01:00', '{"MONDAY"}');
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('dedc6675-ab79-495e-9245-1fc20545eb83', 'Avengers', true, time with time zone '14:48:12.146512+01:00', '{"MONDAY", "TUESDAY"}');
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d5847624-4b50-4d4a-abd3-ed9209a5448b', 'Illuminati', false, time with time zone '12:00:00.146512+01:00', '{"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"}');
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '14:48:12.146512+01:00', '{"MONDAY"}', 24);
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('dedc6675-ab79-495e-9245-1fc20545eb83', 'Avengers', true, time with time zone '14:48:12.146512+01:00', '{"MONDAY", "TUESDAY"}', 24);
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d5847624-4b50-4d4a-abd3-ed9209a5448b', 'Illuminati', false, time with time zone '12:00:00.146512+01:00', '{"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"}', 24);

--- a/src/main/java/patio/group/domain/Group.java
+++ b/src/main/java/patio/group/domain/Group.java
@@ -64,6 +64,9 @@ public final class Group {
   @OneToMany(mappedBy = "group")
   private Set<UserGroup> users;
 
+  @Column(name = "voting_duration")
+  private Integer votingDuration; /* in hours */
+
   /**
    * Creates a new {@link Group} builder
    *
@@ -172,6 +175,24 @@ public final class Group {
    */
   public void setVotingTime(OffsetTime votingTime) {
     this.votingTime = votingTime;
+  }
+
+  /**
+   * Get the duration (in hours) during which the voting will be open
+   *
+   * @return the number of hours
+   */
+  public Integer getVotingDuration() {
+    return votingDuration;
+  }
+
+  /**
+   * Sets the number of hours during which the duration will be open
+   *
+   * @param votingDuration number of hours
+   */
+  public void setVotingDuration(Integer votingDuration) {
+    this.votingDuration = votingDuration;
   }
 
   public Set<UserGroup> getUsers() {

--- a/src/main/java/patio/group/graphql/GroupFetcherUtils.java
+++ b/src/main/java/patio/group/graphql/GroupFetcherUtils.java
@@ -68,17 +68,19 @@ final class GroupFetcherUtils {
     String name = environment.getArgument("name");
     boolean anonymousVote = environment.getArgument("anonymousVote");
     List<DayOfWeek> votingDays = environment.getArgument("votingDays");
+    int votingDuration = environment.getArgument("votingDuration");
     OffsetTime votingTime = environment.getArgument("votingTime");
     Context ctx = environment.getContext();
     User currentUser = ctx.getAuthenticatedUser();
 
     return UpsertGroupInput.newBuilder()
-        .withCurrentUserId(currentUser.getId())
-        .withGroupId(groupId)
-        .withName(name)
-        .withAnonymousVote(anonymousVote)
-        .withVotingDays(votingDays)
-        .withVotingTime(votingTime)
+        .with(i -> i.setCurrentUserId(currentUser.getId()))
+        .with(i -> i.setGroupId(groupId))
+        .with(i -> i.setName(name))
+        .with(i -> i.setAnonymousVote(anonymousVote))
+        .with(i -> i.setVotingDays(votingDays))
+        .with(i -> i.setVotingTime(votingTime))
+        .with(i -> i.setVotingDuration(votingDuration))
         .build();
   }
 }

--- a/src/main/java/patio/group/graphql/UpsertGroupInput.java
+++ b/src/main/java/patio/group/graphql/UpsertGroupInput.java
@@ -20,8 +20,8 @@ package patio.group.graphql;
 import java.time.DayOfWeek;
 import java.time.OffsetTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
+import patio.common.domain.utils.Builder;
 
 /**
  * UpsertGroupInput input. It contains the fields for a Group
@@ -29,38 +29,21 @@ import java.util.UUID;
  * @since 0.1.0
  */
 public class UpsertGroupInput {
-
-  private final UUID groupId;
-  private final String name;
-  private final boolean anonymousVote;
-  private final List<DayOfWeek> votingDays;
-  private final OffsetTime votingTime;
-  private final UUID currentUserId;
+  private UUID groupId;
+  private String name;
+  private boolean anonymousVote;
+  private List<DayOfWeek> votingDays;
+  private OffsetTime votingTime;
+  private int votingDuration;
+  private UUID currentUserId;
 
   /**
-   * Initializes the input
+   * Creates a new builder to create a new instance of type {@link UpsertGroupInput}
    *
-   * @param groupId groups's id
-   * @param name groups's name
-   * @param anonymousVote indicates if the group allows anonymous votes
-   * @param votingDays represents the day of the week
-   * @param votingTime votingTime of the day where the reminder is going to be sent
-   * @param currentUserId current user's id
-   * @since 0.1.0
+   * @return an instance of UpsertGroupInput builder
    */
-  public UpsertGroupInput(
-      UUID groupId,
-      String name,
-      boolean anonymousVote,
-      List<DayOfWeek> votingDays,
-      OffsetTime votingTime,
-      UUID currentUserId) {
-    this.groupId = groupId;
-    this.name = name;
-    this.anonymousVote = anonymousVote;
-    this.votingDays = Optional.ofNullable(votingDays).orElse(List.of());
-    this.votingTime = votingTime;
-    this.currentUserId = currentUserId;
+  public static Builder<UpsertGroupInput> newBuilder() {
+    return Builder.build(UpsertGroupInput::new);
   }
 
   /**
@@ -122,151 +105,81 @@ public class UpsertGroupInput {
   }
 
   /**
-   * Creates a new builder to create a new instance of type {@link UpsertGroupInput}
+   * Gets votingDuration.
    *
-   * @return an instance of {@link Builder}
-   * @since 0.1.0
+   * @return Value of votingDuration.
    */
-  public static Builder newBuilder() {
-    return new Builder();
+  public int getVotingDuration() {
+    return votingDuration;
   }
 
   /**
-   * Builds an instance of type {@link UpsertGroupInput}
+   * Sets the groupId
    *
+   * @param groupId the group's id
    * @since 0.1.0
    */
-  public static class Builder {
+  public void setGroupId(UUID groupId) {
+    this.groupId = groupId;
+  }
 
-    private transient UpsertGroupInput input =
-        new UpsertGroupInput(null, null, false, null, null, null);
+  /**
+   * Sets the name
+   *
+   * @param name the group's name
+   * @since 0.1.0
+   */
+  public void setName(String name) {
+    this.name = name;
+  }
 
-    private Builder() {
-      /* empty */
-    }
+  /**
+   * Sets the anonymousVote
+   *
+   * @param anonymousVote the group's anonymousVote
+   * @since 0.1.0
+   */
+  public void setAnonymousVote(boolean anonymousVote) {
+    this.anonymousVote = anonymousVote;
+  }
 
-    /**
-     * Sets the groupId
-     *
-     * @param groupId the group's id
-     * @return current builder instance
-     * @since 0.1.0
-     */
-    public Builder withGroupId(UUID groupId) {
-      this.input =
-          new UpsertGroupInput(
-              groupId,
-              input.getName(),
-              input.isAnonymousVote(),
-              input.getVotingDays(),
-              input.getVotingTime(),
-              input.getCurrentUserId());
-      return this;
-    }
+  /**
+   * Sets the votingDays
+   *
+   * @param votingDays the group's votingDays
+   * @since 0.1.0
+   */
+  public void setVotingDays(List<DayOfWeek> votingDays) {
+    this.votingDays = votingDays;
+  }
 
-    /**
-     * Sets the name
-     *
-     * @param name the group's name
-     * @return current builder instance
-     * @since 0.1.0
-     */
-    public Builder withName(String name) {
-      this.input =
-          new UpsertGroupInput(
-              input.getGroupId(),
-              name,
-              input.isAnonymousVote(),
-              input.getVotingDays(),
-              input.getVotingTime(),
-              input.getCurrentUserId());
-      return this;
-    }
+  /**
+   * Sets the votingTime
+   *
+   * @param votingTime the group's votingTime
+   * @since 0.1.0
+   */
+  public void setVotingTime(OffsetTime votingTime) {
+    this.votingTime = votingTime;
+  }
 
-    /**
-     * Sets the anonymousVote
-     *
-     * @param anonymousVote the group's anonymousVote
-     * @return current builder instance
-     * @since 0.1.0
-     */
-    public Builder withAnonymousVote(boolean anonymousVote) {
-      this.input =
-          new UpsertGroupInput(
-              input.getGroupId(),
-              input.getName(),
-              anonymousVote,
-              input.getVotingDays(),
-              input.getVotingTime(),
-              input.getCurrentUserId());
-      return this;
-    }
+  /**
+   * Sets the votingTime
+   *
+   * @param votingDuration the group's votingDuration (in hours)
+   * @since 0.1.0
+   */
+  public void setVotingDuration(int votingDuration) {
+    this.votingDuration = votingDuration;
+  }
 
-    /**
-     * Sets the votingDays
-     *
-     * @param votingDays the group's votingDays
-     * @return current builder instance
-     * @since 0.1.0
-     */
-    public Builder withVotingDays(List<DayOfWeek> votingDays) {
-      this.input =
-          new UpsertGroupInput(
-              input.getGroupId(),
-              input.getName(),
-              input.isAnonymousVote(),
-              votingDays,
-              input.getVotingTime(),
-              input.getCurrentUserId());
-      return this;
-    }
-
-    /**
-     * Sets the votingTime
-     *
-     * @param votingTime the group's votingTime
-     * @return current builder instance
-     * @since 0.1.0
-     */
-    public Builder withVotingTime(OffsetTime votingTime) {
-      this.input =
-          new UpsertGroupInput(
-              input.getGroupId(),
-              input.getName(),
-              input.isAnonymousVote(),
-              input.getVotingDays(),
-              votingTime,
-              input.getCurrentUserId());
-      return this;
-    }
-
-    /**
-     * Sets the currentUserId
-     *
-     * @param currentUserId the currentUserId
-     * @return current builder instance
-     * @since 0.1.0
-     */
-    public Builder withCurrentUserId(UUID currentUserId) {
-      this.input =
-          new UpsertGroupInput(
-              input.getGroupId(),
-              input.getName(),
-              input.isAnonymousVote(),
-              input.getVotingDays(),
-              input.getVotingTime(),
-              currentUserId);
-      return this;
-    }
-
-    /**
-     * Returns the instance built with this builder
-     *
-     * @return an instance of type {@link UpsertGroupInput}
-     * @since 0.1.0
-     */
-    public UpsertGroupInput build() {
-      return this.input;
-    }
+  /**
+   * Sets the currentUserId
+   *
+   * @param currentUserId the currentUserId
+   * @since 0.1.0
+   */
+  public void setCurrentUserId(UUID currentUserId) {
+    this.currentUserId = currentUserId;
   }
 }

--- a/src/main/java/patio/group/services/internal/DefaultGroupService.java
+++ b/src/main/java/patio/group/services/internal/DefaultGroupService.java
@@ -92,6 +92,7 @@ public class DefaultGroupService implements GroupService {
             .with(g -> g.setAnonymousVote(input.isAnonymousVote()))
             .with(g -> g.setVotingDays(input.getVotingDays()))
             .with(g -> g.setVotingTime(input.getVotingTime()))
+            .with(g -> g.setVotingDuration(input.getVotingDuration()))
             .build();
 
     Optional<User> user = userRepository.findById(input.getCurrentUserId());
@@ -127,6 +128,7 @@ public class DefaultGroupService implements GroupService {
         .map(b -> b.with(g -> g.setAnonymousVote(input.isAnonymousVote())))
         .map(b -> b.with(g -> g.setVotingDays(input.getVotingDays())))
         .map(b -> b.with(g -> g.setVotingTime(input.getVotingTime())))
+        .map(b -> b.with(g -> g.setVotingDuration(input.getVotingDuration())))
         .map(Builder::build)
         .map(groupRepository::update)
         .orElse(null);

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -30,6 +30,7 @@ type Group {
     members: [User]
     votingDays: [DayOfWeek]
     votingTime: Time
+    votingDuration: Int
     isCurrentUserAdmin: Boolean
     votings(startDateTime: DateTime!, endDateTime: DateTime!): [Voting]
 }
@@ -167,10 +168,14 @@ type Mutation {
     createVote(votingId: ID!, score: Int!, hueMood: String, comment: String, anonymous: Boolean = false): Vote
 
     # creates a group
-    createGroup(name: String!, anonymousVote: Boolean = false, votingTime: Time!, votingDays: [DayOfWeek]!): Group
+    # TODO: mark votingDuration as mandatory (frontend must send it first)
+    createGroup(name: String!, anonymousVote: Boolean = false, votingTime: Time!, votingDays: [DayOfWeek]!,
+        votingDuration: Int = 24): Group
 
     # updates a group
-    updateGroup(groupId: ID!, name: String!, anonymousVote: Boolean = false, votingTime: Time!, votingDays: [DayOfWeek]!): Group
+    # TODO: mark votingDuration as mandatory (frontend must send it first)
+    updateGroup(groupId: ID!, name: String!, anonymousVote: Boolean = false, votingTime: Time!,
+        votingDuration: Int = 24, votingDays: [DayOfWeek]!): Group
 
     # add an user to a group
     addUserToGroup(email: String!, groupId: ID!): Boolean

--- a/src/main/resources/migrations/V13__add_voting_duration_to_group.sql
+++ b/src/main/resources/migrations/V13__add_voting_duration_to_group.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright (C) 2019 Kaleidos Open Source SL
+--
+-- This file is part of PATIO.
+-- PATIO is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- PATIO is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+--
+
+ALTER TABLE groups ADD COLUMN IF NOT EXISTS voting_duration int NULL;

--- a/src/main/resources/migrations/V14__set_voting_duration_to_existing_groups.sql
+++ b/src/main/resources/migrations/V14__set_voting_duration_to_existing_groups.sql
@@ -1,0 +1,21 @@
+--
+-- Copyright (C) 2019 Kaleidos Open Source SL
+--
+-- This file is part of PATIO.
+-- PATIO is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- PATIO is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+--
+
+UPDATE groups SET voting_duration = 24;
+
+ALTER TABLE groups ALTER COLUMN voting_duration SET NOT NULL

--- a/src/test/java/patio/group/repositories/GroupRepositoryTests.java
+++ b/src/test/java/patio/group/repositories/GroupRepositoryTests.java
@@ -17,12 +17,10 @@
  */
 package patio.group.repositories;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import io.micronaut.test.annotation.MicronautTest;
 import java.time.OffsetDateTime;
-import java.time.OffsetTime;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
@@ -37,6 +35,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import patio.group.domain.Group;
 import patio.infrastructure.tests.Fixtures;
 import patio.user.domain.User;
+import patio.voting.domain.Voting;
 
 /**
  * Tests DATABASE integration regarding {@link User} persistence
@@ -68,19 +67,17 @@ public class GroupRepositoryTests {
   }
 
   @Test
-  void testFindAllByDayOfWeekAndVotingTimeLessEq() {
+  void testFindAllGroupsByVotingDayAndVotingTime() {
     // given: a set of fixtures
     fixtures.load(GroupRepositoryTests.class, "testFindAllByDayOfWeekAndVotingTimeLessEq.sql");
 
     // and: some expected ids
     UUID votingToday1 = UUID.fromString("d64db962-3455-11e9-b210-d663bd873d93");
 
-    // when: looking for groups having voting a specific date and before or at a given time
-    OffsetDateTime dateTime = OffsetDateTime.parse("2020-05-04T10:15:30+01:00");
-    OffsetTime nowTime = OffsetTime.parse("11:15:30+01:00");
+    OffsetDateTime dateTime = OffsetDateTime.now();
     String dayOfWeek = dateTime.getDayOfWeek().toString();
 
-    var groupStream = repository.findAllByDayOfWeekAndVotingTimeLessEq(dayOfWeek, nowTime);
+    var groupStream = repository.findAllGroupsInVotingDayAndInVotingPeriod(dayOfWeek, dateTime);
     var idStream = groupStream.map(Group::getId);
 
     // then: we should get groups voting the expected date before or at the given time
@@ -88,18 +85,96 @@ public class GroupRepositoryTests {
   }
 
   @Test
-  void testFindAllByVotingCreatedAtBetween() {
+  void testFindAllGroupsByVotingDayAndNotOpenVotingTime() {
+    // given: a set of fixtures
+    fixtures.load(GroupRepositoryTests.class, "testFindAllByDayOfWeekAndVotingTimeLessEq.sql");
+
+    // and: some expected ids
+    UUID votingToday1 = UUID.fromString("d64db962-3455-11e9-b210-d663bd873d93");
+
+    OffsetDateTime dateTime = OffsetDateTime.now().minusHours(24);
+    String dayOfWeek = dateTime.getDayOfWeek().toString();
+
+    var groupStream = repository.findAllGroupsInVotingDayAndInVotingPeriod(dayOfWeek, dateTime);
+    var idStream = groupStream.map(Group::getId);
+
+    // then: we should get groups voting the expected date before or at the given time
+    assertFalse(idStream.anyMatch(thisUUID(votingToday1)));
+  }
+
+  @Test
+  void testFindAllGroupsByVotingDayAndClosedVotingTime() {
+    // given: a set of fixtures
+    fixtures.load(GroupRepositoryTests.class, "testFindAllByDayOfWeekAndVotingTimeLessEq.sql");
+
+    // and: some expected ids
+    UUID votingToday1 = UUID.fromString("d64db962-3455-11e9-b210-d663bd873d93");
+
+    OffsetDateTime dateTime = OffsetDateTime.now().plusHours(24);
+    String dayOfWeek = dateTime.getDayOfWeek().toString();
+
+    var groupStream = repository.findAllGroupsInVotingDayAndInVotingPeriod(dayOfWeek, dateTime);
+    var idStream = groupStream.map(Group::getId);
+
+    // then: we should get groups voting the expected date before or at the given time
+    assertFalse(idStream.anyMatch(thisUUID(votingToday1)));
+  }
+
+  @Test
+  void testFindAGroupWithVotingForCurrentVotingPeriod() {
     // given: a set of fixtures
     fixtures.load(GroupRepositoryTests.class, "testFindAllByVotingCreatedAtBetween.sql");
 
     UUID expectedGroupId = UUID.fromString("d64db962-3455-11e9-b210-d663bd873d93");
-    OffsetDateTime from = OffsetDateTime.parse("2020-05-04T00:00:00+01:00");
-    OffsetDateTime to = OffsetDateTime.parse("2020-05-04T10:15:30+01:00");
 
-    var votedAlreadyStream = repository.findAllByVotingCreatedAtDateTimeBetween(from, to);
+    var votedAlreadyStream = repository.findAllGroupsWithVotingInCurrentVotingPeriod();
     var idStream = votedAlreadyStream.map(Group::getId);
 
     assertTrue(idStream.anyMatch(thisUUID(expectedGroupId)));
+  }
+
+  @Test
+  void testFindNoneWithVotingForCurrentVotingPeriod() {
+    // given: a set of fixtures
+    fixtures.load(GroupRepositoryTests.class, "testFindAllByDayOfWeekAndVotingTimeLessEq.sql");
+
+    var votedAlreadyStream = repository.findAllGroupsWithVotingInCurrentVotingPeriod();
+    var idStream = votedAlreadyStream.map(Group::getId);
+
+    assertFalse(idStream.findAny().isPresent());
+  }
+
+  @Test
+  void testFindGroupsWithVotingsToExpire() {
+    // given: a set of fixtures
+    fixtures.load(GroupRepositoryTests.class, "testFindExpiredVotingsGroup.sql");
+
+    // and: a time with a group which its voting is out of its voting period
+    OffsetDateTime dateTime = OffsetDateTime.now().plusHours(2);
+    UUID expectedVotingId = UUID.fromString("953951f9-3f6f-421e-a12c-270cfcabb2d0");
+
+    // when: asking to retrieve groups with votings to expire
+    var votingToExpireStream = repository.findAllExpiredVotingsByTime(dateTime);
+    var idStream = votingToExpireStream.map(Voting::getId);
+
+    // the expected group is returned
+    assertTrue(idStream.anyMatch(thisUUID(expectedVotingId)));
+  }
+
+  @Test
+  void testFindGroupsWithNoVotingsToExpire() {
+    // given: a set of fixtures
+    fixtures.load(GroupRepositoryTests.class, "testFindExpiredVotingsGroup.sql");
+
+    // and: a time in both groups in valid voting periods
+    OffsetDateTime dateTime = OffsetDateTime.now().plusMinutes(2);
+
+    // when: asking to retrieve groups with votings to expire
+    var votingToExpireStream = repository.findAllExpiredVotingsByTime(dateTime);
+    var idStream = votingToExpireStream.map(Voting::getId);
+
+    // then : no group is returned
+    assertFalse(idStream.findAny().isPresent());
   }
 
   private Predicate<UUID> thisUUID(UUID uuid) {

--- a/src/test/java/patio/infrastructure/graphql/fetchers/GroupFetcherTests.java
+++ b/src/test/java/patio/infrastructure/graphql/fetchers/GroupFetcherTests.java
@@ -108,7 +108,9 @@ class GroupFetcherTests {
                 "votingDays",
                 group.getVotingDays(),
                 "votingTime",
-                group.getVotingTime()));
+                group.getVotingTime(),
+                "votingDuration",
+                group.getVotingDuration()));
 
     // when: creating a group invoking the service
     GroupFetcher fetchers = new GroupFetcher(mockedService);
@@ -121,6 +123,7 @@ class GroupFetcherTests {
         result.getVotingDays().size(),
         is(group.getVotingDays().size()));
     assertNotNull("time is present", result.getVotingTime());
+    assertNotNull("duration time is present", result.getVotingDuration());
   }
 
   @Test
@@ -175,7 +178,9 @@ class GroupFetcherTests {
                 "votingDays",
                 group.getVotingDays(),
                 "votingTime",
-                group.getVotingTime()));
+                group.getVotingTime(),
+                "votingDuration",
+                group.getVotingDuration()));
 
     // when: creating a group invoking the service
     GroupFetcher fetchers = new GroupFetcher(mockedService);

--- a/src/test/resources/patio/group/repositories/testFindAllByDayOfWeekAndVotingTimeLessEq.sql
+++ b/src/test/resources/patio/group/repositories/testFindAllByDayOfWeekAndVotingTimeLessEq.sql
@@ -17,9 +17,10 @@
 --
 
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea6','Sue Storm', 'sstorm@email.com', 'password', '');
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}');
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d64db962-3455-11e9-b210-d663bd873d94','Avengers', true, time with time zone '11:48:12.146512+01:00', '{"MONDAY"}');
+
+-- Voting times are open from midnight, all day long
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '00:00:00.146512+01:00', '{"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"}', 24);
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d94','Avengers', true, time with time zone '00:00:00.146512+01:00', '{"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"}', 24);
+
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea6', 'f');
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d94','486590a3-fcc1-4657-a9ed-5f0f95dadea6', 'f');
-INSERT INTO voting (id, group_id, voting_stats_id, created_at, created_by) VALUES ('7772e35c-5a87-4ba3-ab93-da8a957037fd', 'd64db962-3455-11e9-b210-d663bd873d93', 'b3576bc7-2cb4-4680-9445-bda0bc615238', '2020-05-04T10:15:30+01:00', '486590a3-fcc1-4657-a9ed-5f0f95dadea6');
-INSERT INTO voting_stats (id, voting_id, created_at, average) VALUES ('b3576bc7-2cb4-4680-9445-bda0bc615238', '7772e35c-5a87-4ba3-ab93-da8a957037fd', now(), 3);

--- a/src/test/resources/patio/group/repositories/testFindAllByVotingCreatedAtBetween.sql
+++ b/src/test/resources/patio/group/repositories/testFindAllByVotingCreatedAtBetween.sql
@@ -17,9 +17,12 @@
 --
 
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea6','Sue Storm', 'sstorm@email.com', 'password', '');
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}');
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d64db962-3455-11e9-b210-d663bd873d94','Avengers', true, time with time zone '11:48:12.146512+01:00', '{"MONDAY"}');
+
+-- Voting times are open from midnight, all day long
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '00:00:00.146512+01:00', '{"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"}', 24);
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d94','Avengers', true, time with time zone '00:00:00.146512+01:00', '{"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"}', 24);
+
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea6', 'f');
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d94','486590a3-fcc1-4657-a9ed-5f0f95dadea6', 'f');
-INSERT INTO voting (id, group_id, voting_stats_id, created_at, created_by) VALUES ('7772e35c-5a87-4ba3-ab93-da8a957037fd', 'd64db962-3455-11e9-b210-d663bd873d93', 'b3576bc7-2cb4-4680-9445-bda0bc615238', '2020-05-04T10:15:30+01:00', '486590a3-fcc1-4657-a9ed-5f0f95dadea6');
-INSERT INTO voting_stats (id, voting_id, created_at, average) VALUES ('b3576bc7-2cb4-4680-9445-bda0bc615238', '7772e35c-5a87-4ba3-ab93-da8a957037fd', now(), 3);
+INSERT INTO voting (id, group_id, voting_stats_id, created_at, created_by) VALUES ('7772e35c-5a87-4ba3-ab93-da8a957037fd', 'd64db962-3455-11e9-b210-d663bd873d93', 'b3576bc7-2cb4-4680-9445-bda0bc615238', now(), '486590a3-fcc1-4657-a9ed-5f0f95dadea6');
+INSERT INTO voting_stats (id, voting_id, created_at, average) VALUES ('b3576bc7-2cb4-4680-9445-bda0bc615238', '7772e35c-5a87-4ba3-ab93-da8a957037fd', now() + interval '5 minutes', 3);

--- a/src/test/resources/patio/group/repositories/testFindExpiredVotingsGroup.sql
+++ b/src/test/resources/patio/group/repositories/testFindExpiredVotingsGroup.sql
@@ -1,0 +1,36 @@
+--
+-- Copyright (C) 2019 Kaleidos Open Source SL
+--
+-- This file is part of PATIO.
+-- PATIO is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- PATIO is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+--
+
+INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea6','Sue Storm', 'sstorm@email.com', 'password', '');
+INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea7','Unknown', 'unknown@email.com', 'password', '');
+
+-- Group with a vote and a voting period of 1 hour
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, now(),  '{"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"}', 1);
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea6', 'f');
+
+INSERT INTO voting (id, group_id, voting_stats_id, created_at, created_by) VALUES ('953951f9-3f6f-421e-a12c-270cfcabb2d0', 'd64db962-3455-11e9-b210-d663bd873d93', 'b3576bc7-2cb4-4680-9445-bda0bc615238', now() + interval '1 minute', '486590a3-fcc1-4657-a9ed-5f0f95dadea6');
+INSERT INTO voting_stats (id, voting_id, created_at, average) VALUES ('b3576bc7-2cb4-4680-9445-bda0bc615238', '953951f9-3f6f-421e-a12c-270cfcabb2d0', now() + interval '1 minute', 3);
+INSERT INTO vote (id, voting_id, created_at, created_by, comment, score) VALUES ('d246d65c-be84-4140-85e1-9cf495523730', '953951f9-3f6f-421e-a12c-270cfcabb2d0', now() + interval '1 minute', '486590a3-fcc1-4657-a9ed-5f0f95dadea6', 'Ut sit labore eius.', 3);
+
+-- Group with a vote and a voting period of 24 hour
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d94','Avengers', true, time with time zone '00:00:00.146512+01:00', '{"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"}', 24);
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d94','486590a3-fcc1-4657-a9ed-5f0f95dadea6', 'f');
+
+INSERT INTO voting (id, group_id, voting_stats_id, created_at, created_by) VALUES ('7772e35c-5a87-4ba3-ab93-da8a957036fd', 'd64db962-3455-11e9-b210-d663bd873d94', '612b08c5-b9e5-4490-a17a-54d3d56def5f', now(), '486590a3-fcc1-4657-a9ed-5f0f95dadea6');
+INSERT INTO voting_stats (id, voting_id, created_at, average) VALUES ('612b08c5-b9e5-4490-a17a-54d3d56def5f', '7772e35c-5a87-4ba3-ab93-da8a957036fd', now() + interval '5 minutes', 3);
+INSERT INTO vote (id, voting_id, created_at, created_by, comment, score) VALUES ('d246d65c-be84-4140-85e1-9cf495523731', '7772e35c-5a87-4ba3-ab93-da8a957036fd', now() + interval '5 minutes', '486590a3-fcc1-4657-a9ed-5f0f95dadea6', 'Ut sit labore eius.', 3);

--- a/src/test/resources/patio/group/repositories/testFindFavouriteGroup.sql
+++ b/src/test/resources/patio/group/repositories/testFindFavouriteGroup.sql
@@ -19,10 +19,10 @@
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea6','Sue Storm', 'sstorm@email.com', 'password', '');
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea7','Unknown', 'unknown@email.com', 'password', '');
 
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}');
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}', 24);
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea6', 'f');
 
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d64db962-3455-11e9-b210-d663bd873d94','Fantastic Five', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}');
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d94','Fantastic Five', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}', 24);
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d94','486590a3-fcc1-4657-a9ed-5f0f95dadea6', 'f');
 
 INSERT INTO voting (id, group_id, voting_stats_id, created_at, created_by) VALUES ('953951f9-3f6f-421e-a12c-270cfcabb2d0', 'd64db962-3455-11e9-b210-d663bd873d93', 'b3576bc7-2cb4-4680-9445-bda0bc615238', '2020-05-04T10:15:30+01:00', '486590a3-fcc1-4657-a9ed-5f0f95dadea6');

--- a/src/test/resources/patio/user/repositories/testFindByIdAndVotingUser.sql
+++ b/src/test/resources/patio/user/repositories/testFindByIdAndVotingUser.sql
@@ -19,7 +19,7 @@
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea6','Sue Storm', 'sstorm@email.com', 'password', '');
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea7','Unknown', 'unknown@email.com', 'password', '');
 
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}');
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}', 24);
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea6', 'f');
 INSERT INTO voting (id, group_id, voting_stats_id, created_at, created_by) VALUES ('7772e35c-5a87-4ba3-ab93-da8a957037fd', 'd64db962-3455-11e9-b210-d663bd873d93', 'b3576bc7-2cb4-4680-9445-bda0bc615238', '2020-05-04T10:15:30+01:00', '486590a3-fcc1-4657-a9ed-5f0f95dadea6');
 INSERT INTO voting_stats (id, voting_id, created_at, average) VALUES ('b3576bc7-2cb4-4680-9445-bda0bc615238', '7772e35c-5a87-4ba3-ab93-da8a957037fd', now(), 3);

--- a/src/test/resources/patio/user/repositories/testListUsersByIdsSameOrderAsListUsers.sql
+++ b/src/test/resources/patio/user/repositories/testListUsersByIdsSameOrderAsListUsers.sql
@@ -22,7 +22,7 @@ INSERT INTO users (id, name, email, password, otp) VALUES ('84d48a35-7659-4710-a
 INSERT INTO users (id, name, email, password, otp) VALUES ('1998c588-d93b-4db6-92e2-a9dbb4cf03b5','Steve Rogers', 'srogers@email.com', 'password', '');
 INSERT INTO users (id, name, email, password, otp) VALUES ('3465094c-5545-4007-a7bc-da2b1a88d9dc','Tony Stark', 'tstark@email.com', 'password', '');
 
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', time with time zone '10:48:12.146512+01:00', '{"MONDAY"}');
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', time with time zone '10:48:12.146512+01:00', '{"MONDAY"}', 24);
 
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea6', 't');
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','c2a771bc-f8c5-4112-a440-c80fa4c8e382', 'f');

--- a/src/test/resources/patio/voting/repositories/testFindAllVotesByMood.sql
+++ b/src/test/resources/patio/voting/repositories/testFindAllVotesByMood.sql
@@ -25,7 +25,7 @@ INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea7','Unknown', 'unknown6@email.com', 'password', '');
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea8','Unknown', 'unknown7@email.com', 'password', '');
 
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}');
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}', 24);
 
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea1', 'f');
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea2', 'f');

--- a/src/test/resources/patio/voting/repositories/testFindByIdAndVotingUser.sql
+++ b/src/test/resources/patio/voting/repositories/testFindByIdAndVotingUser.sql
@@ -19,7 +19,7 @@
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea6','Sue Storm', 'sstorm@email.com', 'password', '');
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea7','Unknown', 'unknown@email.com', 'password', '');
 
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}');
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}', 24);
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea6', 'f');
 INSERT INTO voting (id, group_id, voting_stats_id, created_at, created_by) VALUES ('7772e35c-5a87-4ba3-ab93-da8a957037fd', 'd64db962-3455-11e9-b210-d663bd873d93', 'b3576bc7-2cb4-4680-9445-bda0bc615238', '2020-05-04T10:15:30+01:00', '486590a3-fcc1-4657-a9ed-5f0f95dadea6');
 INSERT INTO voting_stats (id, voting_id, created_at, average) VALUES ('b3576bc7-2cb4-4680-9445-bda0bc615238', '7772e35c-5a87-4ba3-ab93-da8a957037fd', now(), 3);

--- a/src/test/resources/patio/voting/repositories/testFindMovingAverageByGroup.sql
+++ b/src/test/resources/patio/voting/repositories/testFindMovingAverageByGroup.sql
@@ -25,7 +25,7 @@ INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea7','Unknown', 'unknown6@email.com', 'password', '');
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea8','Unknown', 'unknown7@email.com', 'password', '');
 
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}');
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}', 24);
 
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea1', 'f');
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea2', 'f');

--- a/src/test/resources/patio/voting/repositories/testGetAvgVoteCountByVoting.sql
+++ b/src/test/resources/patio/voting/repositories/testGetAvgVoteCountByVoting.sql
@@ -25,7 +25,7 @@ INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea7','Unknown', 'unknown6@email.com', 'password', '');
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea8','Unknown', 'unknown7@email.com', 'password', '');
 
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}');
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}', 24);
 
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea1', 'f');
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea2', 'f');

--- a/src/test/resources/patio/voting/repositories/testGetMaxExpectedVoteCountByVoting.sql
+++ b/src/test/resources/patio/voting/repositories/testGetMaxExpectedVoteCountByVoting.sql
@@ -25,7 +25,7 @@ INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea7','Unknown', 'unknown6@email.com', 'password', '');
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea8','Unknown', 'unknown7@email.com', 'password', '');
 
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}');
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}', 24);
 
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea1', 'f');
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea2', 'f');

--- a/src/test/resources/patio/voting/repositories/testGetVoteCountByVoting.sql
+++ b/src/test/resources/patio/voting/repositories/testGetVoteCountByVoting.sql
@@ -25,7 +25,7 @@ INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea7','Unknown', 'unknown6@email.com', 'password', '');
 INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea8','Unknown', 'unknown7@email.com', 'password', '');
 
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}');
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}', 24);
 
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea1', 'f');
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea2', 'f');

--- a/src/test/resources/patio/voting/repositories/testListUsersByIdsSameOrderAsListUsers.sql
+++ b/src/test/resources/patio/voting/repositories/testListUsersByIdsSameOrderAsListUsers.sql
@@ -22,7 +22,7 @@ INSERT INTO users (id, name, email, password, otp) VALUES ('84d48a35-7659-4710-a
 INSERT INTO users (id, name, email, password, otp) VALUES ('1998c588-d93b-4db6-92e2-a9dbb4cf03b5','Steve Rogers', 'srogers@email.com', 'password', '');
 INSERT INTO users (id, name, email, password, otp) VALUES ('3465094c-5545-4007-a7bc-da2b1a88d9dc','Tony Stark', 'tstark@email.com', 'password', '');
 
-INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}');
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Fantastic Four', true, time with time zone '10:48:12.146512+01:00', '{"MONDAY"}', 24);
 
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea6', 't');
 INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','c2a771bc-f8c5-4112-a440-c80fa4c8e382', 'f');


### PR DESCRIPTION
This MR adds `votingDuration` field to `Group`, reflecting the number of hours a voting will be open to vote.
The application should be updated consequently.

https://tree.taiga.io/project/pabloruiz-kaleidos-patio/us/68?no-milestone=1

![gif](https://media.giphy.com/media/QdbIz3R4GjXAk/giphy.gif)

### Validation Tests

**Commits**
- [ ] Review the code

**Database**
- [ ] Schema
- [ ] Fixtures
- [ ] Migrations

**API operations**
- [ ] The new field should be publicly exposed in the API
- [ ] Creating/updating a group should consider the new field (and default values when omitted - 24 hours)

**Votings / Votes**
The new concept _voting period_ arises (`votingTime` + `votingDuration`), and it's critical to pay special attention to:
- [ ] The creation of new votings/notifications when a new voting period begins
- [ ] Existing votings should be expired as soon as It's detected that a voting it's out of its voting period
- [ ] That votes are legal while created during the voting period (or illegal and forbidden in any other case)