### PR TITLE
Us/6/back/invite users to teams cron

### DIFF
--- a/src/main/java/patio/group/domain/Group.java
+++ b/src/main/java/patio/group/domain/Group.java
@@ -23,6 +23,7 @@ import java.time.OffsetTime;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -196,7 +197,9 @@ public final class Group {
   }
 
   public Set<UserGroup> getUsers() {
-    return users;
+    return users.stream()
+        .filter(userGroup -> !userGroup.getAcceptancePending())
+        .collect(Collectors.toSet());
   }
 
   public void setUsers(Set<UserGroup> users) {

--- a/src/main/java/patio/group/domain/UserGroup.java
+++ b/src/main/java/patio/group/domain/UserGroup.java
@@ -17,13 +17,8 @@
  */
 package patio.group.domain;
 
-import javax.persistence.Column;
-import javax.persistence.EmbeddedId;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.MapsId;
-import javax.persistence.Table;
+import java.time.OffsetDateTime;
+import javax.persistence.*;
 import patio.common.domain.utils.Builder;
 import patio.user.domain.User;
 
@@ -50,6 +45,22 @@ public final class UserGroup {
 
   @Column(name = "is_admin")
   private boolean admin;
+
+  @OneToOne
+  @JoinColumn(name = "inviting_id", referencedColumnName = "id")
+  private User invitedBy;
+
+  @Column(name = "is_acceptance_pending")
+  private boolean acceptancePending;
+
+  @Column(name = "invitation_otp")
+  private String invitationOtp;
+
+  @Column(name = "otp_creation_date")
+  private OffsetDateTime otpCreationDateTime;
+
+  @Column(name = "member_from_date")
+  private OffsetDateTime memberFromDateTime;
 
   /**
    * Creates a new {@link UserGroup} from an {@link User} and a {@link Group}
@@ -85,6 +96,33 @@ public final class UserGroup {
    */
   public User getUser() {
     return user;
+  }
+
+  /**
+   * Returns if the member is still pending
+   *
+   * @return an instance of {@link User}
+   */
+  public Boolean getAcceptancePending() {
+    return acceptancePending;
+  }
+
+  /**
+   * Returns the {@link User} who sends the invitation to join the group
+   *
+   * @return the user
+   */
+  public User getInvitedBy() {
+    return invitedBy;
+  }
+
+  /**
+   * Returns the invitation's otp
+   *
+   * @return an instance of {@link User}
+   */
+  public String getInvitationOtp() {
+    return invitationOtp;
   }
 
   /**
@@ -133,20 +171,83 @@ public final class UserGroup {
   }
 
   /**
-   * Returns the user group id
+   * Returns the user group id.
    *
-   * @return the {@link UserGroup} id
+   * @return the {@link UserGroup} id.
    */
   public UserGroupKey getId() {
     return id;
   }
 
   /**
-   * Sets user group's id
+   * Gets the time when the otp is created.
+   *
+   * @return creation date time.
+   */
+  public OffsetDateTime getOtpCreationDateTime() {
+    return otpCreationDateTime;
+  }
+
+  /**
+   * Gets when the user join the group officially.
+   *
+   * @return membership date time.
+   */
+  public OffsetDateTime getMemberFromDateTime() {
+    return memberFromDateTime;
+  }
+
+  /**
+   * Sets user group's id.
    *
    * @param id sets {@link UserGroup} id
    */
   public void setId(UserGroupKey id) {
     this.id = id;
+  }
+
+  /**
+   * Sets whether the user is acceptance pending.
+   *
+   * @param acceptancePending sets {@link UserGroup} id.
+   */
+  public void setAcceptancePending(boolean acceptancePending) {
+    this.acceptancePending = acceptancePending;
+  }
+
+  /**
+   * Sets the user's invitation otp.
+   *
+   * @param invitationOtp the one-time password.
+   */
+  public void setInvitationOtp(String invitationOtp) {
+    this.invitationOtp = invitationOtp;
+  }
+
+  /**
+   * Sets the user who invite to join the group.
+   *
+   * @param invitedBy the {@link User} who invites to join the group.
+   */
+  public void setInvitedBy(User invitedBy) {
+    this.invitedBy = invitedBy;
+  }
+
+  /**
+   * Sets when the user join the group officially.
+   *
+   * @param otpCreationDateTime the {@link OffsetDateTime}
+   */
+  public void setOtpCreationDateTime(OffsetDateTime otpCreationDateTime) {
+    this.otpCreationDateTime = otpCreationDateTime;
+  }
+
+  /**
+   * Sets when the otp is created.
+   *
+   * @param memberFromDateTime the {@link OffsetDateTime}
+   */
+  public void setMemberFromDateTime(OffsetDateTime memberFromDateTime) {
+    this.memberFromDateTime = memberFromDateTime;
   }
 }

--- a/src/main/java/patio/group/graphql/AcceptInvitationToGroupInput.java
+++ b/src/main/java/patio/group/graphql/AcceptInvitationToGroupInput.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of PATIO.
+ * PATIO is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PATIO is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+ */
+package patio.group.graphql;
+
+import java.util.UUID;
+
+/**
+ * AddUserToGroupInput input. It contains the ids for a user and a group
+ *
+ * @since 0.1.0
+ */
+public class AcceptInvitationToGroupInput {
+  private final UUID currentUserId;
+  private final String otp;
+
+  /**
+   * Returns the group invitation's otp
+   *
+   * @return the email of the user
+   * @since 0.1.0
+   */
+  public String getOtp() {
+    return otp;
+  }
+
+  /**
+   * Returns the id of the current user
+   *
+   * @return the id of the current user
+   * @since 0.1.0
+   */
+  public UUID getCurrentUserId() {
+    return currentUserId;
+  }
+
+  /**
+   * Initializes the input with the user email and the group id
+   *
+   * @param currentUserId the id of the current user
+   * @param otp the group invitation's otp
+   * @since 0.1.0
+   */
+  public AcceptInvitationToGroupInput(UUID currentUserId, String otp) {
+    this.currentUserId = currentUserId;
+    this.otp = otp;
+  }
+}

--- a/src/main/java/patio/group/graphql/GroupProvider.java
+++ b/src/main/java/patio/group/graphql/GroupProvider.java
@@ -53,6 +53,8 @@ public class GroupProvider implements QueryProvider, MutationProvider {
             .dataFetcher("createGroup", groupFetcher::createGroup)
             .dataFetcher("updateGroup", groupFetcher::updateGroup)
             .dataFetcher("addUserToGroup", userGroupFetcher::addUserToGroup)
+            .dataFetcher("inviteMembersToGroup", userGroupFetcher::inviteMembersToGroup)
+            .dataFetcher("acceptInvitationToGroup", userGroupFetcher::acceptInvitationToGroup)
             .dataFetcher("leaveGroup", userGroupFetcher::leaveGroup);
   }
 

--- a/src/main/java/patio/group/graphql/InviteMembersToGroupInput.java
+++ b/src/main/java/patio/group/graphql/InviteMembersToGroupInput.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of PATIO.
+ * PATIO is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PATIO is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+ */
+package patio.group.graphql;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * AddUserToGroupInput input. It contains the ids for a user and a group
+ *
+ * @since 0.1.0
+ */
+public class InviteMembersToGroupInput {
+  private final List<String> emailList;
+  private final UUID groupId;
+  private final UUID currentUserId;
+
+  /**
+   * Returns the email of the user
+   *
+   * @return the email of the user
+   * @since 0.1.0
+   */
+  public List<String> getEmailList() {
+    return emailList;
+  }
+
+  /**
+   * Returns the id of the group
+   *
+   * @return the id of the group
+   * @since 0.1.0
+   */
+  public UUID getGroupId() {
+    return groupId;
+  }
+
+  /**
+   * Returns the id of the current user
+   *
+   * @return the id of the current user
+   * @since 0.1.0
+   */
+  public UUID getCurrentUserId() {
+    return currentUserId;
+  }
+
+  /**
+   * Initializes the input with the user email and the group id
+   *
+   * @param currentUserId the id of the current user
+   * @param email the email of the user
+   * @param groupId the id of the group
+   * @since 0.1.0
+   */
+  public InviteMembersToGroupInput(UUID currentUserId, List<String> email, UUID groupId) {
+    this.currentUserId = currentUserId;
+    this.emailList = email;
+    this.groupId = groupId;
+  }
+}

--- a/src/main/java/patio/group/graphql/UserGroupFetcher.java
+++ b/src/main/java/patio/group/graphql/UserGroupFetcher.java
@@ -26,6 +26,7 @@ import patio.group.domain.UserGroup;
 import patio.group.services.UserGroupService;
 import patio.infrastructure.graphql.Context;
 import patio.infrastructure.graphql.ResultUtils;
+import patio.user.domain.GroupMember;
 import patio.user.domain.User;
 
 /**
@@ -68,6 +69,32 @@ public class UserGroupFetcher {
   }
 
   /**
+   * Adds a list of users to a group
+   *
+   * @param env GraphQL execution environment
+   * @return an instance of {@link DataFetcherResult} because it could return errors
+   * @since 0.1.0
+   */
+  public DataFetcherResult<Boolean> inviteMembersToGroup(DataFetchingEnvironment env) {
+    InviteMembersToGroupInput input = UserGroupFetcherUtils.inviteMembersToGroup(env);
+    Result<Boolean> result = service.inviteMembersToGroup(input);
+    return ResultUtils.render(result);
+  }
+
+  /**
+   * Add a user with a valid OTP to a group
+   *
+   * @param env GraphQL execution environment
+   * @return an instance of {@link DataFetcherResult} because it could return errors
+   * @since 0.1.0
+   */
+  public DataFetcherResult<Group> acceptInvitationToGroup(DataFetchingEnvironment env) {
+    AcceptInvitationToGroupInput input = UserGroupFetcherUtils.acceptInvitationToGroup(env);
+
+    return ResultUtils.render(service.acceptInvitationToGroup(input));
+  }
+
+  /**
    * Get if the current user an admin of the group
    *
    * @param env GraphQL execution environment
@@ -89,8 +116,9 @@ public class UserGroupFetcher {
    * @return a list of available {@link User}
    * @since 0.1.0
    */
-  public Iterable<User> listUsersGroup(DataFetchingEnvironment env) {
+  public Iterable<GroupMember> listUsersGroup(DataFetchingEnvironment env) {
     ListUsersGroupInput input = UserGroupFetcherUtils.listUsersGroupInput(env);
+
     return service.listUsersGroup(input);
   }
 

--- a/src/main/java/patio/group/graphql/UserGroupFetcherUtils.java
+++ b/src/main/java/patio/group/graphql/UserGroupFetcherUtils.java
@@ -18,6 +18,7 @@
 package patio.group.graphql;
 
 import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
 import java.util.UUID;
 import patio.group.domain.Group;
 import patio.infrastructure.graphql.Context;
@@ -72,6 +73,41 @@ final class UserGroupFetcherUtils {
     User currentUser = ctx.getAuthenticatedUser();
 
     return new AddUserToGroupInput(currentUser.getId(), email, groupId);
+  }
+
+  /**
+   * Creates a {@link InviteMembersToGroupInput} from the data coming from the {@link
+   * DataFetchingEnvironment}
+   *
+   * @param environment the GraphQL {@link DataFetchingEnvironment}
+   * @return an instance of {@link InviteMembersToGroupInput}
+   * @since 0.1.0
+   */
+  /* default */ static InviteMembersToGroupInput inviteMembersToGroup(
+      DataFetchingEnvironment environment) {
+    List<String> emailList = environment.getArgument("emailList");
+    UUID groupId = environment.getArgument("groupId");
+    Context ctx = environment.getContext();
+    User currentUser = ctx.getAuthenticatedUser();
+
+    return new InviteMembersToGroupInput(currentUser.getId(), emailList, groupId);
+  }
+
+  /**
+   * Creates a {@link AcceptInvitationToGroupInput} from the data coming from the {@link
+   * DataFetchingEnvironment}
+   *
+   * @param environment the GraphQL {@link DataFetchingEnvironment}
+   * @return an instance of {@link AcceptInvitationToGroupInput}
+   * @since 0.1.0
+   */
+  /* default */ static AcceptInvitationToGroupInput acceptInvitationToGroup(
+      DataFetchingEnvironment environment) {
+    String otp = environment.getArgument("otp");
+    Context ctx = environment.getContext();
+    User currentUser = ctx.getAuthenticatedUser();
+
+    return new AcceptInvitationToGroupInput(currentUser.getId(), otp);
   }
 
   /**

--- a/src/main/java/patio/group/services/InvitationsScheduling.java
+++ b/src/main/java/patio/group/services/InvitationsScheduling.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of PATIO.
+ * PATIO is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PATIO is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+ */
+package patio.group.services;
+
+/**
+ * Scheduled tasks
+ *
+ * @since 0.1.0
+ */
+public interface InvitationsScheduling {
+
+  /**
+   * Checks whether a new voting should be created, and if so, creates the new {@link
+   * patio.voting.domain.Voting} instance and sends a notification to all members of that voting's
+   * group
+   *
+   * @since 0.1.0
+   */
+  void scheduleInvitations();
+}

--- a/src/main/java/patio/group/services/UserGroupService.java
+++ b/src/main/java/patio/group/services/UserGroupService.java
@@ -17,12 +17,12 @@
  */
 package patio.group.services;
 
+import java.util.List;
 import java.util.UUID;
 import patio.common.domain.utils.Result;
 import patio.group.domain.Group;
-import patio.group.graphql.AddUserToGroupInput;
-import patio.group.graphql.LeaveGroupInput;
-import patio.group.graphql.ListUsersGroupInput;
+import patio.group.graphql.*;
+import patio.user.domain.GroupMember;
 import patio.user.domain.User;
 
 /**
@@ -42,6 +42,24 @@ public interface UserGroupService {
   Result<Boolean> addUserToGroup(AddUserToGroupInput input);
 
   /**
+   * Adds an user to a group, if the current user is admin of the group
+   *
+   * @param input member's emails and group information
+   * @return an instance of {@link Result} (Boolean | {@link Error})
+   * @since 0.1.0
+   */
+  Result<Boolean> inviteMembersToGroup(InviteMembersToGroupInput input);
+
+  /**
+   * Adds a user with a valid group invitation's otp to a group
+   *
+   * @param input current user and otp information
+   * @return an instance of {@link Result} (Boolean | {@link Error})
+   * @since 0.1.0
+   */
+  Result<Group> acceptInvitationToGroup(AcceptInvitationToGroupInput input);
+
+  /**
    * Fetches the list of users in a Group. ifMatches the user is not allowed to build them, returns
    * an empty list
    *
@@ -49,7 +67,7 @@ public interface UserGroupService {
    * @return a list of {@link User} instances
    * @since 0.1.0
    */
-  Iterable<User> listUsersGroup(ListUsersGroupInput input);
+  List<GroupMember> listUsersGroup(ListUsersGroupInput input);
 
   /**
    * Make the current user leave the specified group

--- a/src/main/java/patio/group/services/internal/DefaultUserGroupService.java
+++ b/src/main/java/patio/group/services/internal/DefaultUserGroupService.java
@@ -17,9 +17,7 @@
  */
 package patio.group.services.internal;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import javax.inject.Singleton;
 import javax.transaction.Transactional;
 import patio.common.domain.utils.NotPresent;
@@ -27,13 +25,12 @@ import patio.common.domain.utils.Result;
 import patio.group.domain.Group;
 import patio.group.domain.UserGroup;
 import patio.group.domain.UserGroupKey;
-import patio.group.graphql.AddUserToGroupInput;
-import patio.group.graphql.LeaveGroupInput;
-import patio.group.graphql.ListUsersGroupInput;
+import patio.group.graphql.*;
 import patio.group.repositories.GroupRepository;
 import patio.group.repositories.UserGroupRepository;
 import patio.group.services.UserGroupService;
 import patio.infrastructure.utils.OptionalUtils;
+import patio.user.domain.GroupMember;
 import patio.user.domain.User;
 import patio.user.repositories.UserRepository;
 
@@ -49,25 +46,29 @@ public class DefaultUserGroupService implements UserGroupService {
   private final transient GroupRepository groupRepository;
   private final transient UserRepository userRepository;
   private final transient UserGroupRepository userGroupRepository;
-
+  private final transient InvitationService invitationService;
   /**
    * Initializes service by using the database repositories
    *
    * @param groupRepository an instance of {@link GroupRepository}
    * @param userRepository an instance of {@link UserRepository}
    * @param userGroupRepository an instance of {@link UserGroupRepository}
+   * @param invitationService to allow managing of group invitations
    * @since 0.1.0
    */
   public DefaultUserGroupService(
       GroupRepository groupRepository,
       UserRepository userRepository,
-      UserGroupRepository userGroupRepository) {
+      UserGroupRepository userGroupRepository,
+      InvitationService invitationService) {
     this.groupRepository = groupRepository;
     this.userRepository = userRepository;
     this.userGroupRepository = userGroupRepository;
+    this.invitationService = invitationService;
   }
 
   @Override
+  // TODO: Delete it ASAP and use group's invitations instead
   public Result<Boolean> addUserToGroup(AddUserToGroupInput input) {
     Optional<Group> group = groupRepository.findById(input.getGroupId());
     Optional<User> user = userRepository.findByEmail(input.getEmail());
@@ -84,18 +85,42 @@ public class DefaultUserGroupService implements UserGroupService {
         .then(() -> addUserToGroupIfSuccess(user, group));
   }
 
-  private Boolean addUserToGroupIfSuccess(Optional<User> user, Optional<Group> group) {
-    return OptionalUtils.combine(user, group)
-        .into(UserGroup::new)
-        .map(userGroupRepository::save)
-        .isPresent();
+  @Override
+  public Result<Boolean> inviteMembersToGroup(InviteMembersToGroupInput input) {
+    Optional<Group> group = groupRepository.findById(input.getGroupId());
+    Optional<User> currentUser = userRepository.findById(input.getCurrentUserId());
+
+    NotPresent notPresent = new NotPresent();
+    UserIsGroupAdmin userIsGroupAdmin = new UserIsGroupAdmin(userGroupRepository);
+
+    return Result.<Boolean>create()
+        .thenCheck(() -> notPresent.check(group))
+        .thenCheck(() -> userIsGroupAdmin.check(input.getCurrentUserId(), input.getGroupId()))
+        .then(
+            () ->
+                invitationService.inviteGroupMembers(
+                    input.getEmailList(), group.get(), currentUser.get()));
   }
 
   @Override
-  public Iterable<User> listUsersGroup(ListUsersGroupInput input) {
+  public Result<Group> acceptInvitationToGroup(AcceptInvitationToGroupInput input) {
+    Optional<User> currentUser = userRepository.findById(input.getCurrentUserId());
+    Optional<UserGroup> userGroup =
+        userGroupRepository.findByUserAndOtp(currentUser.get(), input.getOtp());
+
+    NotPresent notPresent = new NotPresent();
+
+    return Result.<UserGroup>create()
+        .thenCheck(() -> notPresent.check(userGroup))
+        .then(() -> invitationService.activateMembership(userGroup.get()))
+        .map(UserGroup::getGroup);
+  }
+
+  @Override
+  public List<GroupMember> listUsersGroup(ListUsersGroupInput input) {
     return groupRepository
         .findById(input.getGroupId())
-        .map(userRepository::findAllByGroup)
+        .map(userRepository::findAllGroupMembersByGroup)
         .orElseGet(List::of);
   }
 
@@ -134,5 +159,12 @@ public class DefaultUserGroupService implements UserGroupService {
         .findById(new UserGroupKey(userId, groupId))
         .map(UserGroup::isAdmin)
         .orElse(false);
+  }
+
+  private Boolean addUserToGroupIfSuccess(Optional<User> user, Optional<Group> group) {
+    return OptionalUtils.combine(user, group)
+        .into(UserGroup::new)
+        .map(userGroupRepository::save)
+        .isPresent();
   }
 }

--- a/src/main/java/patio/group/services/internal/InvitationSchedulingService.java
+++ b/src/main/java/patio/group/services/internal/InvitationSchedulingService.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of PATIO.
+ * PATIO is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PATIO is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+ */
+package patio.group.services.internal;
+
+import io.micronaut.context.annotation.Value;
+import io.micronaut.scheduling.annotation.Scheduled;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import javax.inject.Singleton;
+import javax.transaction.Transactional;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import patio.group.domain.UserGroup;
+import patio.group.repositories.GroupRepository;
+import patio.group.repositories.UserGroupRepository;
+import patio.group.services.InvitationsScheduling;
+import patio.infrastructure.email.domain.Email;
+import patio.infrastructure.email.services.EmailService;
+import patio.infrastructure.email.services.internal.EmailComposerService;
+import patio.infrastructure.email.services.internal.templates.URLResolverService;
+import patio.security.services.CryptoService;
+import patio.user.domain.User;
+
+/**
+ * Business logic regarding {@link UserGroup} domain
+ *
+ * @since 0.1.0
+ */
+@Singleton
+public class InvitationSchedulingService implements InvitationsScheduling {
+  private static final Logger LOG = LoggerFactory.getLogger(InvitationSchedulingService.class);
+
+  private final transient String acceptGroupUrl;
+  private final transient GroupRepository groupRepository;
+  private final transient UserGroupRepository userGroupRepository;
+  private final transient EmailComposerService emailComposerService;
+  private final transient EmailService emailService;
+  private final transient URLResolverService urlResolverService;
+  private final transient CryptoService cryptoService;
+
+  /**
+   * Initializes service by using the database repositories
+   *
+   * @param acceptGroupUrl to get the link from configuration
+   * @param groupRepository an instance of {@link GroupRepository}
+   * @param userGroupRepository an instance of {@link UserGroupRepository}
+   * @param emailService to be able to send notifications to group members
+   * @param emailComposerService service to compose the {@link Email} notifications
+   * @param urlResolverService to resolve possible link urls for emails
+   * @param cryptoService an instance of {@link CryptoService}
+   * @since 0.1.0
+   */
+  public InvitationSchedulingService(
+      @Value("${front.urls.accept-group:none}") String acceptGroupUrl,
+      GroupRepository groupRepository,
+      UserGroupRepository userGroupRepository,
+      EmailService emailService,
+      EmailComposerService emailComposerService,
+      URLResolverService urlResolverService,
+      CryptoService cryptoService) {
+    this.acceptGroupUrl = acceptGroupUrl;
+    this.groupRepository = groupRepository;
+    this.userGroupRepository = userGroupRepository;
+    this.emailComposerService = emailComposerService;
+    this.emailService = emailService;
+    this.urlResolverService = urlResolverService;
+    this.cryptoService = cryptoService;
+  }
+
+  /**
+   * Checks whether exist any pending member without an invitation (OTP) to join each corresponding
+   * group, and sends a notification with a new OTP inviting those potential members by theirs
+   * emails account.
+   *
+   * @since 0.1.0
+   */
+  @Scheduled(fixedRate = "30s", initialDelay = "30s")
+  @Override
+  public void scheduleInvitations() {
+    checkGroupInvitations();
+  }
+
+  /** Sends group's invitations to pending members */
+  @Transactional
+  private void checkGroupInvitations() {
+    LOG.info("checking group invitations");
+    groupRepository
+        .findAll()
+        .forEach(
+            group ->
+                userGroupRepository
+                    .findAllPendingUninvitedByGroup(group)
+                    .forEach(this::sendInvitation));
+  }
+
+  private UserGroup generateOtp(UserGroup uGroup) {
+    final String randomOTP = cryptoService.hash(RandomStringUtils.randomAlphanumeric(17));
+    uGroup.setInvitationOtp(randomOTP);
+    uGroup.setOtpCreationDateTime(OffsetDateTime.now());
+    return userGroupRepository.update(uGroup);
+  }
+
+  private UserGroup sendInvitation(UserGroup uGroup) {
+    LOG.info(
+        String.format(
+            "notifying %s to join %s", uGroup.getUser().getEmail(), uGroup.getGroup().getName()));
+    generateOtp(uGroup);
+    emailService.send(this.composeInvitation(uGroup));
+
+    return uGroup;
+  }
+
+  @SuppressWarnings("PMD.UseConcurrentHashMap")
+  private Email composeInvitation(UserGroup uGroup) {
+    var user = uGroup.getUser();
+    var group = uGroup.getGroup();
+    var invitationOtp = uGroup.getInvitationOtp();
+    var invitingUser = uGroup.getInvitedBy();
+    var emailRecipient = user.getEmail();
+
+    Map<String, Object> subjectMessageVars =
+        Map.of("invitingUser", invitingUser.getName(), "groupName", group.getName());
+    String emailSubject =
+        emailComposerService.getMessage("invitationToGroup.subject", subjectMessageVars);
+    String disclaimerMessage = emailComposerService.getMessage("invitationToGroup.disclaimer");
+    String emailBodyTemplate = emailComposerService.getMessage("invitationToGroup.bodyTemplate");
+
+    Map<String, Object> greetingMessageVars =
+        Map.of("invitingUser", invitingUser.getName(), "groupName", group.getName());
+    String greetingsMessage =
+        emailComposerService.getMessage("invitationToGroup.greetings", greetingMessageVars);
+    String patioIntroMessage = emailComposerService.getMessage("invitationToGroup.patioIntro");
+    String acceptMessage = emailComposerService.getMessage("invitationToGroup.acceptButton");
+    String patioTeamMessage = emailComposerService.getMessage("invitationToGroup.patioTeam");
+    String welcome = emailComposerService.getMessage("invitationToGroup.welcome");
+
+    Map<String, Object> emailBodyVars = new HashMap<>();
+    emailBodyVars.put("subject", emailSubject);
+    emailBodyVars.put("greetings", greetingsMessage);
+    emailBodyVars.put("patioIntro", patioIntroMessage);
+    emailBodyVars.put("link", this.getInvitationToGroupLink(user, group.getId(), invitationOtp));
+    emailBodyVars.put("accept", acceptMessage);
+    emailBodyVars.put("disclaimer", disclaimerMessage);
+    emailBodyVars.put("welcome", welcome);
+    emailBodyVars.put("patioTeam", patioTeamMessage);
+
+    return emailComposerService.composeEmail(
+        emailRecipient, emailSubject, emailBodyTemplate, emailBodyVars);
+  }
+
+  private String getInvitationToGroupLink(User user, UUID groupId, String otp) {
+    var isNewUser = user.isRegistrationPending();
+    return urlResolverService.resolve(this.acceptGroupUrl, groupId, isNewUser, otp);
+  }
+}

--- a/src/main/java/patio/group/services/internal/InvitationService.java
+++ b/src/main/java/patio/group/services/internal/InvitationService.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of PATIO.
+ * PATIO is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PATIO is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+ */
+package patio.group.services.internal;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import javax.inject.Singleton;
+import javax.transaction.Transactional;
+import patio.group.domain.Group;
+import patio.group.domain.UserGroup;
+import patio.group.repositories.UserGroupRepository;
+import patio.user.domain.User;
+import patio.user.repositories.UserRepository;
+import patio.user.services.internal.DefaultUserService;
+
+/**
+ * Business logic regarding {@link UserGroup} domain
+ *
+ * @since 0.1.0
+ */
+@Singleton
+@Transactional
+public class InvitationService {
+  private final transient UserRepository userRepository;
+  private final transient UserGroupRepository userGroupRepository;
+  private final transient DefaultUserService defaultUserService;
+
+  /**
+   * Initializes service by using the database repositories
+   *
+   * @param userRepository an instance of {@link UserRepository}
+   * @param userGroupRepository an instance of {@link UserGroupRepository}
+   * @param defaultUserService to allow creating pending-registration users
+   * @since 0.1.0
+   */
+  public InvitationService(
+      UserRepository userRepository,
+      UserGroupRepository userGroupRepository,
+      DefaultUserService defaultUserService) {
+    this.userRepository = userRepository;
+    this.userGroupRepository = userGroupRepository;
+    this.defaultUserService = defaultUserService;
+  }
+
+  /**
+   * Sends group's invitations to the provided email List
+   *
+   * @param emailList the user's emails te be invited to join the group
+   * @param group the group to became a member from
+   * @param currentUser the user that is inviting
+   * @return true
+   */
+  public Boolean inviteGroupMembers(List<String> emailList, Group group, User currentUser) {
+    // pre-register in patio those emails that are not from users
+    defaultUserService.createPendingUsers(emailList);
+
+    // resend invitations to those ones explicitly indicated
+    findAllToResendInvitation(group, emailList).forEach(ug -> this.setAsPending(ug, currentUser));
+
+    // send invitations to those ones never invited before
+    findAllToInviteFirstTime(group, emailList)
+        .forEach(u -> this.addPendingMembersToGroup(u, group, currentUser));
+
+    return true;
+  }
+
+  /**
+   * Set a pending member in a group as fully active
+   *
+   * @param userGroup the {@link UserGroup} to activate
+   * @return the {@link UserGroup}
+   */
+  public UserGroup activateMembership(UserGroup userGroup) {
+    userGroup.setAcceptancePending(false);
+    userGroup.setInvitationOtp(null);
+    userGroup.setMemberFromDateTime(OffsetDateTime.now());
+    userGroupRepository.save(userGroup);
+
+    return userGroup;
+  }
+
+  private Stream<UserGroup> findAllToResendInvitation(Group group, List<String> emailList) {
+    Stream<UserGroup> alreadyPending = userGroupRepository.findAllPendingByGroup(group);
+
+    return alreadyPending.filter(ug -> emailList.contains(ug.getUser().getEmail()));
+  }
+
+  private Stream<User> findAllToInviteFirstTime(Group group, List<String> emailList) {
+    List<User> alreadyInvited = userRepository.findAllByGroup(group);
+
+    return userRepository
+        .findAllByEmailInList(emailList)
+        .filter(Predicate.not(alreadyInvited::contains));
+  }
+
+  private void setAsPending(UserGroup userGroup, User currentUser) {
+    userGroup.setAcceptancePending(true);
+    userGroup.setInvitationOtp(null);
+    userGroup.setOtpCreationDateTime(null);
+    userGroup.setInvitedBy(currentUser);
+    userGroupRepository.save(userGroup);
+  }
+
+  private void addPendingMembersToGroup(User user, Group group, User currentUser) {
+    UserGroup userGroup = new UserGroup(user, group);
+    setAsPending(userGroup, currentUser);
+  }
+}

--- a/src/main/java/patio/user/domain/GroupMember.java
+++ b/src/main/java/patio/user/domain/GroupMember.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of PATIO.
+ * PATIO is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PATIO is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+ */
+package patio.user.domain;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.commons.codec.digest.DigestUtils;
+
+/**
+ * Represents a user of patio and its data as a member of any group
+ *
+ * @since 0.1.0
+ */
+public final class GroupMember {
+  /* default */ UUID id;
+  /* default */ String name;
+  /* default */ String email;
+  /* default */ Boolean registrationPending;
+  /* default */ Boolean acceptancePending;
+  /* default */ User invitedBy;
+  /* default */ OffsetDateTime otpCreationDateTime;
+  /* default */ OffsetDateTime memberFromDateTime;
+
+  /**
+   * Creates a new instance of {@link GroupMember}
+   *
+   * @param id the user id
+   * @param name the user name
+   * @param email the user email
+   * @param registrationPending weather the user is still pending to join patio
+   * @param acceptancePending weather the user is still pending to join patio
+   * @param invitedBy the user that invites to join the group
+   * @param otpCreationDateTime when the otp is created
+   * @param memberFromDateTime when the user join the group officially
+   */
+  public GroupMember(
+      UUID id,
+      String name,
+      String email,
+      Boolean registrationPending,
+      Boolean acceptancePending,
+      User invitedBy,
+      OffsetDateTime otpCreationDateTime,
+      OffsetDateTime memberFromDateTime) {
+    this.id = id;
+    this.name = name;
+    this.email = email;
+    this.registrationPending = registrationPending;
+    this.acceptancePending = acceptancePending;
+    this.invitedBy = invitedBy;
+    this.otpCreationDateTime = otpCreationDateTime;
+    this.memberFromDateTime = memberFromDateTime;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(UUID id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public Boolean getRegistrationPending() {
+    return registrationPending;
+  }
+
+  public void setRegistrationPending(Boolean registrationPending) {
+    this.registrationPending = registrationPending;
+  }
+
+  public Boolean getAcceptancePending() {
+    return acceptancePending;
+  }
+
+  public void setAcceptancePending(Boolean acceptancePending) {
+    this.acceptancePending = acceptancePending;
+  }
+
+  public User getInvitedBy() {
+    return invitedBy;
+  }
+
+  public void setInvitedBy(User invitedBy) {
+    this.invitedBy = invitedBy;
+  }
+
+  public OffsetDateTime getOtpCreationDateTime() {
+    return otpCreationDateTime;
+  }
+
+  public void setOtpCreationDateTime(OffsetDateTime otpCreationDateTime) {
+    this.otpCreationDateTime = otpCreationDateTime;
+  }
+
+  public OffsetDateTime getMemberFromDateTime() {
+    return memberFromDateTime;
+  }
+
+  public void setMemberFromDateTime(OffsetDateTime memberFromDateTime) {
+    this.memberFromDateTime = memberFromDateTime;
+  }
+
+  /**
+   * Generates a user's md5 hash which can be used for third party services such as Gravatar.
+   *
+   * @return gets a md5 hash from the user's email
+   * @since 0.1.0
+   */
+  public String getHash() {
+    return Optional.ofNullable(this.email)
+        .map(String::trim)
+        .map(String::toLowerCase)
+        .map(DigestUtils::md5Hex)
+        .orElse("");
+  }
+}

--- a/src/main/java/patio/user/domain/User.java
+++ b/src/main/java/patio/user/domain/User.java
@@ -21,6 +21,7 @@ import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -52,6 +53,9 @@ public final class User {
 
   @OneToMany(mappedBy = "user")
   private Set<UserGroup> groups;
+
+  @Column(name = "is_registration_pending")
+  private boolean registrationPending;
 
   /**
    * Creates a builder to create instances of type {@link User}
@@ -177,7 +181,9 @@ public final class User {
    * @return set of UserGroups
    */
   public Set<UserGroup> getGroups() {
-    return groups;
+    return groups.stream()
+        .filter(userGroup -> !userGroup.getAcceptancePending())
+        .collect(Collectors.toSet());
   }
 
   /**
@@ -187,6 +193,24 @@ public final class User {
    */
   public void setGroups(Set<UserGroup> groups) {
     this.groups = groups;
+  }
+
+  /**
+   * Gets whether the user is registration pending
+   *
+   * @return registrationPending
+   */
+  public boolean isRegistrationPending() {
+    return registrationPending;
+  }
+
+  /**
+   * Sets whether the user is registration pending
+   *
+   * @param registrationPending boolean value
+   */
+  public void setRegistrationPending(boolean registrationPending) {
+    this.registrationPending = registrationPending;
   }
 
   /**

--- a/src/main/java/patio/user/repositories/internal/MicroUserRepository.java
+++ b/src/main/java/patio/user/repositories/internal/MicroUserRepository.java
@@ -20,8 +20,6 @@ package patio.user.repositories.internal;
 import io.micronaut.data.annotation.Repository;
 import java.util.Optional;
 import javax.persistence.EntityManager;
-import patio.group.domain.Group;
-import patio.group.domain.UserGroup;
 import patio.infrastructure.persistence.MicroBaseRepository;
 import patio.user.domain.User;
 import patio.user.repositories.UserRepository;
@@ -37,16 +35,6 @@ public abstract class MicroUserRepository extends MicroBaseRepository implements
    */
   public MicroUserRepository(EntityManager entityManager) {
     super(entityManager);
-  }
-
-  @Override
-  public Iterable<User> findAllByGroup(Group group) {
-    var builder = getEntityManager().getCriteriaBuilder();
-    var query = builder.createQuery(User.class);
-    var root = query.from(UserGroup.class);
-    var select = query.select(root.get("user")).where(builder.equal(root.get("group"), group));
-
-    return getEntityManager().createQuery(select).getResultList();
   }
 
   @Override

--- a/src/main/java/patio/user/services/UserService.java
+++ b/src/main/java/patio/user/services/UserService.java
@@ -54,4 +54,11 @@ public interface UserService {
    * @since 0.1.0
    */
   Iterable<User> listUsersByIds(List<UUID> ids);
+
+  /**
+   * Creates registration pending users in patio for those not-existing emails
+   *
+   * @param emailList the user's emails to be invited
+   */
+  void createPendingUsers(List<String> emailList);
 }

--- a/src/main/java/patio/user/services/internal/DefaultUserService.java
+++ b/src/main/java/patio/user/services/internal/DefaultUserService.java
@@ -67,4 +67,20 @@ public class DefaultUserService implements UserService {
         .sorted(comparator)
         .collect(Collectors.toList());
   }
+
+  @Override
+  public void createPendingUsers(List<String> emailList) {
+    List<String> pendingEmails = emailList.stream().collect(Collectors.toList());
+    pendingEmails.removeIf(email -> !userRepository.findByEmail(email).isEmpty());
+    pendingEmails.forEach(this::createRegistrationPendingUser);
+  }
+
+  private void createRegistrationPendingUser(String email) {
+    User pendingUser =
+        User.builder()
+            .with(u -> u.setEmail(email))
+            .with(u -> u.setRegistrationPending(true))
+            .build();
+    userRepository.save(pendingUser);
+  }
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -27,12 +27,31 @@ type Group {
     id: ID
     anonymousVote: Boolean
     name: String
-    members: [User]
+    members: [GroupMember]
     votingDays: [DayOfWeek]
     votingTime: Time
     votingDuration: Int
     isCurrentUserAdmin: Boolean
     votings(startDateTime: DateTime!, endDateTime: DateTime!): [Voting]
+}
+
+type GroupMember {
+    id: ID
+    name: String
+    email: String
+    hash: String
+    registrationPending: Boolean
+    acceptancePending: Boolean
+    otpCreationDateTime: DateTime
+    memberFromDateTime: DateTime
+    invitedBy: User
+}
+
+type User {
+    id: ID
+    name: String
+    hash: String
+    registrationPending: Boolean
 }
 
 type UserProfile {
@@ -42,12 +61,6 @@ type UserProfile {
     hash: String
     groups: [Group]
     favouriteGroup: Group
-}
-
-type User {
-    id: ID
-    name: String
-    hash: String
 }
 
 type VotePaginationResult {
@@ -179,6 +192,12 @@ type Mutation {
 
     # add an user to a group
     addUserToGroup(email: String!, groupId: ID!): Boolean
+
+    # add the given members to a group (they may not be yet users)
+    inviteMembersToGroup(emailList: [String]!, groupId: ID!): Boolean
+
+    # a user accept an invitation to join a group
+    acceptInvitationToGroup(otp: String!): Group
 
     # add an user to a group
     leaveGroup(groupId: ID!): Boolean

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -31,3 +31,12 @@ resetPassword.notRequested=If you didn’t request a new password, you can safel
 resetPassword.thanks=Regards,
 resetPassword.patioTeam=patio.team
 resetPassword.bodyTemplate=templates/resetPassword.pug
+
+invitationToGroup.subject={invitingUser} has invited you to Patio
+invitationToGroup.greetings=Hi, {currentUser} wants you to be part of the {groupName} on patio.
+invitationToGroup.patioIntro=patio.team is a place where you and the rest of your team members share how you feel and be in the loop.
+invitationToGroup.acceptButton=accept invitation
+invitationToGroup.disclaimer=You are receiving this email because someone sent you an invitation. We will never use your email to contact you or spam you.
+invitationToGroup.welcome=Welcome,
+invitationToGroup.patioTeam=patio.team
+invitationToGroup.bodyTemplate=templates/invitationToGroup.pug

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -31,3 +31,12 @@ resetPassword.notRequested=Si no solicitaste una nueva constraseña, por favor, 
 resetPassword.thanks=Un saludo,
 resetPassword.patioTeam=patio.team
 resetPassword.bodyTemplate=templates/resetPassword.pug
+
+invitationToGroup.subject={invitingUser} te ha invitado a Patio
+invitationToGroup.greetings=Hola, {invitingUser} quiere que seas parte de {groupName} en patio.
+invitationToGroup.patioIntro=patio.team es un lugar donde tú y el resto de los miembros de tu equipo compartís cómo os sentís y podáis estar al día.
+invitationToGroup.acceptButton=aceptar invitación
+invitationToGroup.disclaimer=Recibes este correo porque alguien te ha mandado una invitación. Nosotros nunca nos pondremos en contacto o mandaremos ningún correo sin tu consentimiento.
+invitationToGroup.welcome=Bienvenido,
+invitationToGroup.patioTeam=patio.team
+invitationToGroup.bodyTemplate=templates/invitationToGroup.pug

--- a/src/main/resources/messages_fr.properties
+++ b/src/main/resources/messages_fr.properties
@@ -31,3 +31,12 @@ resetPassword.notRequested=Si vous n'avez pas demandé de nouveau mot de passe, 
 resetPassword.thanks=Au revoir,
 resetPassword.patioTeam=patio.team
 resetPassword.bodyTemplate=templates/resetPassword.pug
+
+invitationToGroup.subject={invitingUser} vous a invité à Patio
+invitationToGroup.greetings=Salut, {currentUser} veut que vous fassiez partie de {groupName} à Patio
+invitationToGroup.patioIntro=patio.team est un endroit où vous et le reste des membres de votre équipe partagez ce que vous ressentez et vous pouvez être à jour.
+invitationToGroup.acceptButton=accepter l'invitation
+invitationToGroup.disclaimer= Vous recevez cet e-mail car quelqu'un vous a envoyé une invitation. Nous ne contacterons ni n'enverrons jamais d'e-mail sans votre consentement.
+invitationToGroup.welcome=Bienvenue,
+invitationToGroup.patioTeam=patio.team
+invitationToGroup.bodyTemplate=templates/invitationToGroup.pug

--- a/src/main/resources/migrations/V15__add_invitation_fields_to_users_grops.sql
+++ b/src/main/resources/migrations/V15__add_invitation_fields_to_users_grops.sql
@@ -1,0 +1,26 @@
+--
+-- Copyright (C) 2019 Kaleidos Open Source SL
+--
+-- This file is part of PATIO.
+-- PATIO is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- PATIO is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+--
+
+ALTER TABLE users
+    ALTER COLUMN name DROP NOT NULL,
+    ADD COLUMN IF NOT EXISTS is_registration_pending boolean NULL DEFAULT false,
+    ADD CONSTRAINT name_nullable CHECK (
+        name <> ''
+        OR
+        is_registration_pending IS TRUE
+    );

--- a/src/main/resources/migrations/V16__add_acceptance_pending_to_users_groups.sql
+++ b/src/main/resources/migrations/V16__add_acceptance_pending_to_users_groups.sql
@@ -1,0 +1,26 @@
+--
+-- Copyright (C) 2019 Kaleidos Open Source SL
+--
+-- This file is part of PATIO.
+-- PATIO is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- PATIO is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+--
+
+ALTER TABLE users_groups
+    ADD COLUMN IF NOT EXISTS is_acceptance_pending boolean NULL default FALSE,
+    ADD COLUMN IF NOT EXISTS invitation_otp varchar(200) NULL,
+    ADD COLUMN IF NOT EXISTS otp_creation_date timestamp with time zone NULL,
+    ADD COLUMN IF NOT EXISTS member_from_date timestamp with time zone NULL,
+    ADD COLUMN IF NOT EXISTS inviting_id UUID NULL,
+    ADD CONSTRAINT inviting_id FOREIGN KEY (inviting_id) REFERENCES users(id);
+

--- a/src/main/resources/templates/invitationToGroup.pug
+++ b/src/main/resources/templates/invitationToGroup.pug
@@ -1,0 +1,11 @@
+div
+    p #{greetings}
+    p #{patioIntro}
+    p
+      div
+       a(href='#{link}') #{accept}
+    p
+    p #{disclaimer}
+
+    p #{welcome}
+    p #{patioTeam}

--- a/src/test/java/patio/group/repositories/UserGroupRepositoryTests.java
+++ b/src/test/java/patio/group/repositories/UserGroupRepositoryTests.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of PATIO.
+ * PATIO is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PATIO is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+ */
+package patio.group.repositories;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.iterableWithSize;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.micronaut.test.annotation.MicronautTest;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import patio.group.domain.Group;
+import patio.infrastructure.tests.Fixtures;
+import patio.user.domain.User;
+import patio.user.repositories.UserRepository;
+
+/**
+ * Tests DATABASE integration regarding {@link User} persistence
+ *
+ * @since 0.1.0
+ */
+@MicronautTest
+@Testcontainers
+public class UserGroupRepositoryTests {
+
+  @Container
+  @SuppressWarnings("unused")
+  private static PostgreSQLContainer DATABASE = new PostgreSQLContainer();
+
+  @Inject transient Flyway flyway;
+
+  @Inject transient UserGroupRepository userGroupRepository;
+  @Inject transient UserRepository userRepository;
+  @Inject transient GroupRepository groupRepository;
+
+  @Inject transient Fixtures fixtures;
+
+  @BeforeEach
+  void loadFixtures() {
+    flyway.migrate();
+  }
+
+  @AfterEach
+  void cleanFixtures() {
+    flyway.clean();
+  }
+
+  @Test
+  void testFindByUserAndOtp() {
+    // given: a pre-loaded fixtures
+    fixtures.load(UserGroupRepositoryTests.class, "testInvitationOtpToGroup.sql");
+
+    // and: a user is invited to join a group
+    var optionalUser =
+        userRepository.findById(UUID.fromString("3465094c-5545-4007-a7bc-da2b1a88d9dc"));
+
+    // when: providing the user and his otp
+    var userGroup =
+        optionalUser
+            .map(u -> userGroupRepository.findByUserAndOtp(u, "$1Otp/a2b1a88d9d1"))
+            .orElse(null);
+
+    // then: the return should be the expected
+    assertEquals(userGroup.get().getUser(), optionalUser.get());
+  }
+
+  @Test
+  void testFindAllPendingByGroup() {
+    // given: a pre-loaded fixtures
+    fixtures.load(UserGroupRepositoryTests.class, "testInvitationOtpToGroup.sql");
+
+    // and: a group with invited members
+    var optionalGroup =
+        groupRepository.findById(UUID.fromString("d64db962-3455-11e9-b210-d663bd873d93"));
+
+    // when: providing the user and his otp
+    var userGroupStream =
+        optionalGroup.map(userGroupRepository::findAllPendingByGroup).orElse(null);
+
+    // then: the return should be the expected
+    assertThat(userGroupStream.collect(Collectors.toList()), iterableWithSize(2));
+  }
+
+  @Test
+  void testFindAllPendingUninvitedByGroup() {
+    // given: a pre-loaded fixtures
+    fixtures.load(UserGroupRepositoryTests.class, "testUninvitedToGroup.sql");
+
+    // and: a group with invited and uninvited members (with or without an OTP)
+    var optionalGroup =
+        groupRepository.findById(UUID.fromString("d64db962-3455-11e9-b210-d663bd873d93"));
+
+    System.out.println(String.format("===> " + optionalGroup.map(Group::getName)));
+
+    // when: providing the user and his otp
+    var userGroupList =
+        optionalGroup.map(userGroupRepository::findAllPendingUninvitedByGroup).orElse(null);
+
+    // then: the return should be the expected
+    assertThat(userGroupList, iterableWithSize(2));
+  }
+}

--- a/src/test/java/patio/group/services/InvitationSchedulingServiceTests.java
+++ b/src/test/java/patio/group/services/InvitationSchedulingServiceTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of PATIO.
+ * PATIO is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PATIO is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+ */
+package patio.group.services;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import patio.group.domain.Group;
+import patio.group.domain.UserGroup;
+import patio.group.repositories.GroupRepository;
+import patio.group.repositories.UserGroupRepository;
+import patio.group.services.internal.InvitationSchedulingService;
+import patio.infrastructure.email.services.EmailService;
+import patio.infrastructure.email.services.internal.EmailComposerService;
+import patio.infrastructure.email.services.internal.templates.URLResolverService;
+import patio.security.services.CryptoService;
+import patio.user.domain.User;
+
+public class InvitationSchedulingServiceTests {
+
+  @Test
+  public void testSendFirstTimeInvitations() {
+    // setup: mocked repositories
+    var groupRepository = mock(GroupRepository.class);
+    var userGroupRepository = mock(UserGroupRepository.class);
+    var emailService = mock(EmailService.class);
+    var emailComposerService = mock(EmailComposerService.class);
+    var urlResolverService = mock(URLResolverService.class);
+    var cryptoService = mock(CryptoService.class);
+
+    // and: mocked data (an inviting group admin)
+    var group = random(Group.class, "users");
+    var groupAdmin = random(User.class);
+
+    // and: mocked data (pending user)
+    var invitedEmail = random(String.class);
+    var invitationOtp = random(String.class);
+    var invitedUser = random(User.class);
+    invitedUser.setEmail(invitedEmail);
+    var invitedUserGroup = new UserGroup(invitedUser, group);
+    invitedUserGroup.setAcceptancePending(true);
+    invitedUserGroup.setInvitationOtp(invitationOtp);
+    invitedUserGroup.setInvitedBy(groupAdmin);
+
+    // and: mocked returns
+    when(groupRepository.findAll()).thenReturn(List.of(group));
+    when(userGroupRepository.findAllPendingUninvitedByGroup(group))
+        .thenReturn(List.of(invitedUserGroup));
+
+    // when: calling the service method
+    var invitationSchedulingService =
+        new InvitationSchedulingService(
+            random(String.class),
+            groupRepository,
+            userGroupRepository,
+            emailService,
+            emailComposerService,
+            urlResolverService,
+            cryptoService);
+    invitationSchedulingService.scheduleInvitations();
+
+    // then: the behaviour is correct
+    verify(userGroupRepository, times(1)).findAllPendingUninvitedByGroup(any());
+    verify(emailService, times(1)).send(any());
+    verify(emailComposerService, times(6)).getMessage(any());
+    verify(emailComposerService, times(2)).getMessage(any(), any());
+    verify(emailComposerService, times(1)).composeEmail(any(), any(), any(), any());
+    verify(urlResolverService, times(1)).resolve(any(), any(), any(), any());
+    verify(cryptoService, times(1)).hash(any());
+    verify(userGroupRepository, times(1)).update(invitedUserGroup);
+  }
+}

--- a/src/test/java/patio/group/services/InvitationServiceTests.java
+++ b/src/test/java/patio/group/services/InvitationServiceTests.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of PATIO.
+ * PATIO is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PATIO is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+ */
+package patio.group.services;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import patio.group.domain.Group;
+import patio.group.domain.UserGroup;
+import patio.group.domain.UserGroupKey;
+import patio.group.repositories.UserGroupRepository;
+import patio.group.services.internal.InvitationService;
+import patio.user.domain.User;
+import patio.user.repositories.UserRepository;
+import patio.user.services.internal.DefaultUserService;
+
+public class InvitationServiceTests {
+
+  @Test
+  @SuppressFBWarnings(
+      value = "UC_USELESS_OBJECT",
+      justification = "It is required for the test to pass")
+  public void testSendFirstTimeInvitations() {
+    // setup: mocked repositories
+    var userRepository = mock(UserRepository.class);
+    var userGroupRepository = mock(UserGroupRepository.class);
+    var defaultUserService = Mockito.mock(DefaultUserService.class);
+
+    // and: a user pending to be invited
+    var group = random(Group.class, "users");
+    var invitedEmail = random(String.class);
+    var invitedEmailList = List.of(invitedEmail);
+    var invitedUser = random(User.class);
+    invitedUser.setEmail(invitedEmail);
+    var invitedUserGroup = new UserGroup(invitedUser, group);
+    invitedUserGroup.setAcceptancePending(true);
+
+    // and: a group admin (that invite the previous user)
+    var currentUser = random(User.class);
+    var userGroupAdmin = new UserGroup(currentUser, group);
+    userGroupAdmin.setAdmin(true);
+
+    // and: mocked returns
+    when(userRepository.findByEmail(any(String.class))).thenReturn(Optional.of(currentUser));
+    when(userRepository.findAllByEmailInList(invitedEmailList)).thenReturn(Stream.of(invitedUser));
+    when(userRepository.findAllByGroup(group)).thenReturn(Collections.emptyList());
+    when(userGroupRepository.findById(any(UserGroupKey.class)))
+        .thenReturn(Optional.of(userGroupAdmin))
+        .thenReturn(Optional.empty());
+    when(userGroupRepository.findAllPendingByGroup(any())).thenReturn(Stream.empty());
+
+    // when: calling the service method
+    // when: calling the service method
+    var invitationService =
+        new InvitationService(userRepository, userGroupRepository, defaultUserService);
+    var result = invitationService.inviteGroupMembers(invitedEmailList, group, currentUser);
+
+    // then: the result is successful
+    assertTrue(result);
+
+    // and: and the invocations are correct
+    verify(defaultUserService, times(1)).createPendingUsers(invitedEmailList);
+    verify(userGroupRepository, times(1)).findAllPendingByGroup(any());
+    verify(userRepository, times(1)).findAllByGroup(any());
+    verify(userRepository, times(1)).findAllByEmailInList(any());
+    verify(userGroupRepository, times(1)).save(any());
+  }
+
+  @Test
+  public void testResendInvitations() {
+    // setup: mocked repositories
+    var userRepository = mock(UserRepository.class);
+    var userGroupRepository = mock(UserGroupRepository.class);
+    var defaultUserService = Mockito.mock(DefaultUserService.class);
+
+    // and: a pending user to be invited
+    var group = random(Group.class, "users");
+    var invitedEmail = random(String.class);
+    var invitedEmailList = List.of(invitedEmail);
+    var invitedUser = random(User.class);
+    invitedUser.setEmail(invitedEmail);
+    var invitedUserGroup = new UserGroup(invitedUser, group);
+    invitedUserGroup.setAcceptancePending(true);
+
+    // and: a group admin that invite the previous user
+    var currentUser = random(User.class);
+    var userGroupAdmin = new UserGroup(currentUser, group);
+    userGroupAdmin.setAdmin(true);
+
+    // and: mocked returns
+    when(userRepository.findByEmail(any(String.class))).thenReturn(Optional.of(currentUser));
+    when(userGroupRepository.findById(any(UserGroupKey.class)))
+        .thenReturn(Optional.of(userGroupAdmin))
+        .thenReturn(Optional.empty());
+    when(userGroupRepository.findAllPendingByGroup(any())).thenReturn(Stream.of(invitedUserGroup));
+
+    // when: calling the service method
+    var invitationService =
+        new InvitationService(userRepository, userGroupRepository, defaultUserService);
+    var result = invitationService.inviteGroupMembers(invitedEmailList, group, currentUser);
+
+    // then: the result is successful
+    assertTrue(result);
+
+    // and: and the invocations are correct
+    verify(defaultUserService, times(1)).createPendingUsers(invitedEmailList);
+    verify(userGroupRepository, times(1)).findAllPendingByGroup(any());
+    verify(userRepository, times(1)).findAllByGroup(any());
+    verify(userGroupRepository, times(1)).save(any());
+  }
+
+  @Test
+  public void testActivateMembership() {
+    // setup: mocked repositories
+    var userRepository = mock(UserRepository.class);
+    var userGroupRepository = mock(UserGroupRepository.class);
+    var defaultUserService = Mockito.mock(DefaultUserService.class);
+
+    // and: mocked data
+    var userGroup = random(UserGroup.class);
+    userGroup.setAcceptancePending(true);
+    userGroup.setInvitationOtp(random(String.class));
+
+    // when: calling the service method
+    var invitationService =
+        new InvitationService(userRepository, userGroupRepository, defaultUserService);
+    var result = invitationService.activateMembership(userGroup);
+
+    // then: the result is the expected
+    assertEquals(result, userGroup);
+    assertEquals(result.getAcceptancePending(), false);
+    assertEquals(result.getInvitationOtp(), null);
+
+    // and: and the invocations are correct
+    verify(userGroupRepository, times(1)).save(any());
+  }
+}

--- a/src/test/java/patio/group/services/UserGroupServiceTests.java
+++ b/src/test/java/patio/group/services/UserGroupServiceTests.java
@@ -25,16 +25,23 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import patio.group.domain.Group;
 import patio.group.domain.UserGroup;
 import patio.group.domain.UserGroupKey;
+import patio.group.graphql.AcceptInvitationToGroupInput;
 import patio.group.graphql.AddUserToGroupInput;
+import patio.group.graphql.InviteMembersToGroupInput;
+import patio.group.graphql.ListUsersGroupInput;
 import patio.group.repositories.GroupRepository;
 import patio.group.repositories.UserGroupRepository;
 import patio.group.services.internal.DefaultUserGroupService;
+import patio.group.services.internal.InvitationService;
+import patio.user.domain.GroupMember;
 import patio.user.domain.User;
 import patio.user.repositories.UserRepository;
 
@@ -46,6 +53,7 @@ public class UserGroupServiceTests {
     var userRepository = mock(UserRepository.class);
     var groupRepository = mock(GroupRepository.class);
     var userGroupRepository = mock(UserGroupRepository.class);
+    var groupInvitationsService = Mockito.mock(InvitationService.class);
 
     // and: dummy data
     var loggedUser = Optional.of(random(User.class));
@@ -62,7 +70,8 @@ public class UserGroupServiceTests {
 
     // when: trying to add a user into a group
     var userGroupService =
-        new DefaultUserGroupService(groupRepository, userRepository, userGroupRepository);
+        new DefaultUserGroupService(
+            groupRepository, userRepository, userGroupRepository, groupInvitationsService);
     var userToInvite = Optional.of(random(User.class));
     var input =
         new AddUserToGroupInput(
@@ -85,6 +94,7 @@ public class UserGroupServiceTests {
     var userRepository = mock(UserRepository.class);
     var groupRepository = mock(GroupRepository.class);
     var userGroupRepository = mock(UserGroupRepository.class);
+    var groupInvitationsService = Mockito.mock(InvitationService.class);
 
     // and: dummy data
     var loggedUser = Optional.of(random(User.class));
@@ -99,7 +109,8 @@ public class UserGroupServiceTests {
 
     // when: trying to add a user into a group
     var userGroupService =
-        new DefaultUserGroupService(groupRepository, userRepository, userGroupRepository);
+        new DefaultUserGroupService(
+            groupRepository, userRepository, userGroupRepository, groupInvitationsService);
     var userToInvite = Optional.of(random(User.class));
     var input =
         new AddUserToGroupInput(
@@ -121,6 +132,7 @@ public class UserGroupServiceTests {
     var userRepository = mock(UserRepository.class);
     var groupRepository = mock(GroupRepository.class);
     var userGroupRepository = mock(UserGroupRepository.class);
+    var groupInvitationsService = Mockito.mock(InvitationService.class);
 
     // and: dummy data
     var loggedUser = Optional.of(random(User.class));
@@ -137,7 +149,8 @@ public class UserGroupServiceTests {
 
     // when: trying to add a user into a group
     var userGroupService =
-        new DefaultUserGroupService(groupRepository, userRepository, userGroupRepository);
+        new DefaultUserGroupService(
+            groupRepository, userRepository, userGroupRepository, groupInvitationsService);
     var userToInvite = Optional.of(random(User.class));
     var input =
         new AddUserToGroupInput(
@@ -151,5 +164,119 @@ public class UserGroupServiceTests {
     verify(userRepository, times(1)).findByEmail(any(String.class));
     verify(groupRepository, times(1)).findById(any(UUID.class));
     verify(userGroupRepository, times(2)).findById(any(UserGroupKey.class));
+  }
+
+  @Test
+  public void testInviteMembersToGroup() {
+    // setup: mocked repositories
+    var userRepository = mock(UserRepository.class);
+    var groupRepository = mock(GroupRepository.class);
+    var userGroupRepository = mock(UserGroupRepository.class);
+    var invitationService = Mockito.mock(InvitationService.class);
+
+    // and: dummy data
+    var loggedUser = Optional.of(random(User.class));
+    when(userRepository.findById(any(UUID.class))).thenReturn(loggedUser);
+    var group = Optional.of(random(Group.class, "users"));
+    when(groupRepository.findById(any(UUID.class))).thenReturn(group);
+
+    var userGroupAdmin = new UserGroup(loggedUser.get(), group.get());
+    userGroupAdmin.setAdmin(true);
+    when(userGroupRepository.findById(any(UserGroupKey.class)))
+        .thenReturn(Optional.of(userGroupAdmin))
+        .thenReturn(Optional.of(new UserGroup(random(User.class), random(Group.class))));
+
+    // when: trying to add a user into a group
+    var userGroupService =
+        new DefaultUserGroupService(
+            groupRepository, userRepository, userGroupRepository, invitationService);
+    var input =
+        new InviteMembersToGroupInput(
+            loggedUser.get().getId(), List.of(random(String.class)), group.get().getId());
+    var result = userGroupService.inviteMembersToGroup(input);
+
+    // then: the result is successful
+    assertTrue(result.isSuccess());
+
+    // and: and the invocations are correct
+    verify(userRepository, times(1)).findById(loggedUser.get().getId());
+    verify(groupRepository, times(1)).findById(group.get().getId());
+    verify(invitationService, times(1))
+        .inviteGroupMembers(input.getEmailList(), group.get(), loggedUser.get());
+  }
+
+  @Test
+  public void testAcceptInvitationToGroup() {
+    // setup: mocked repositories
+    var userRepository = mock(UserRepository.class);
+    var groupRepository = mock(GroupRepository.class);
+    var userGroupRepository = mock(UserGroupRepository.class);
+    var invitationService = Mockito.mock(InvitationService.class);
+
+    // and: dummy data
+    User loggedUser = random(User.class);
+    when(userRepository.findById(any(UUID.class))).thenReturn(Optional.of(loggedUser));
+    var group = Optional.of(random(Group.class, "users"));
+    when(groupRepository.findById(any(UUID.class))).thenReturn(group);
+
+    var invitationOtp = random(String.class);
+    var pendingUserGroup = new UserGroup(loggedUser, group.get());
+    pendingUserGroup.setAcceptancePending(true);
+    pendingUserGroup.setInvitationOtp(invitationOtp);
+    when(userGroupRepository.findByUserAndOtp(loggedUser, invitationOtp))
+        .thenReturn(Optional.of(pendingUserGroup))
+        .thenReturn(Optional.of(new UserGroup(random(User.class), random(Group.class))));
+
+    when(invitationService.activateMembership(pendingUserGroup)).thenReturn(pendingUserGroup);
+
+    // when: trying to add a user into a group
+    var userGroupService =
+        new DefaultUserGroupService(
+            groupRepository, userRepository, userGroupRepository, invitationService);
+    var input = new AcceptInvitationToGroupInput(loggedUser.getId(), invitationOtp);
+    var result = userGroupService.acceptInvitationToGroup(input);
+
+    // then: the result is successful
+    assertTrue(result.isSuccess());
+
+    // and: and the invocations are correct
+    verify(userRepository, times(1)).findById(loggedUser.getId());
+    verify(userGroupRepository, times(1)).findByUserAndOtp(loggedUser, input.getOtp());
+    verify(invitationService, times(1)).activateMembership(pendingUserGroup);
+  }
+
+  @Test
+  public void testListUsersGroup() {
+    // setup: mocked repositories
+    var userRepository = mock(UserRepository.class);
+    var groupRepository = mock(GroupRepository.class);
+    var userGroupRepository = mock(UserGroupRepository.class);
+    var invitationService = Mockito.mock(InvitationService.class);
+
+    // and: dummy data
+    var group = Optional.of(random(Group.class, "users"));
+    when(groupRepository.findById(group.get().getId())).thenReturn(group);
+    User loggedUser = random(User.class);
+    when(userRepository.findAllGroupMembersByGroup(group.get()))
+        .thenReturn(List.of(random(GroupMember.class)));
+
+    var invitationOtp = random(String.class);
+    var pendingUserGroup = new UserGroup(loggedUser, group.get());
+    pendingUserGroup.setAcceptancePending(true);
+    pendingUserGroup.setInvitationOtp(invitationOtp);
+    when(userGroupRepository.findByUserAndOtp(loggedUser, invitationOtp))
+        .thenReturn(Optional.of(pendingUserGroup))
+        .thenReturn(Optional.of(new UserGroup(random(User.class), random(Group.class))));
+
+    // when: trying to add a user into a group
+    var userGroupService =
+        new DefaultUserGroupService(
+            groupRepository, userRepository, userGroupRepository, invitationService);
+    var input = new ListUsersGroupInput(loggedUser.getId(), group.get().getId());
+    userGroupService.listUsersGroup(input);
+
+    // then: the result is successful
+    verify(userRepository, times(1)).findAllGroupMembersByGroup(group.get());
+    verify(groupRepository, times(1)).findById(group.get().getId());
   }
 }

--- a/src/test/java/patio/infrastructure/graphql/fetchers/GroupFetcherTests.java
+++ b/src/test/java/patio/infrastructure/graphql/fetchers/GroupFetcherTests.java
@@ -83,6 +83,32 @@ class GroupFetcherTests {
   }
 
   @Test
+  void testGetMyFavouriteGroup() {
+    // given: an group
+    Group group = random(Group.class);
+
+    // and: an user
+    User user = random(User.class);
+
+    // and: a mocking service
+    var mockedService = Mockito.mock(DefaultGroupService.class);
+
+    // and: mocking service's behavior
+    Mockito.when(mockedService.getMyFavouriteGroup(any())).thenReturn(Result.result(group));
+
+    // and: a mocked environment
+    var mockedEnvironment =
+        FetcherTestUtils.generateMockedEnvironment(user, Map.of("id", group.getId()));
+
+    // when: fetching build group invoking the service
+    GroupFetcher fetchers = new GroupFetcher(mockedService);
+    DataFetcherResult<Group> result = fetchers.getMyFavouriteGroup(mockedEnvironment);
+
+    // then: check certain assertions should be met
+    assertThat("the group is found", result.getData(), is(group));
+  }
+
+  @Test
   void testCreateGroup() {
     // given: a group
     Group group = random(Group.class);

--- a/src/test/java/patio/user/domain/GroupMemberTests.java
+++ b/src/test/java/patio/user/domain/GroupMemberTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2019 Kaleidos Open Source SL
+ *
+ * This file is part of PATIO.
+ * PATIO is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PATIO is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+ */
+package patio.user.domain;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests some functions in domain classes other than getters and setters.
+ *
+ * @since 0.1.0
+ */
+public class GroupMemberTests {
+
+  @Test
+  void testConstructor() {
+    // given: some known values
+    var uuid = random(UUID.class);
+    var text = random(String.class);
+    var user = random(User.class);
+    var time = OffsetDateTime.now();
+
+    // when: creating a new instance
+    GroupMember groupMember = new GroupMember(uuid, text, text, true, true, user, time, time);
+
+    // then: they are correctly created
+    assertEquals(groupMember.getId(), uuid);
+    assertEquals(groupMember.getName(), text);
+    assertEquals(groupMember.getEmail(), text);
+    assertEquals(groupMember.getRegistrationPending(), true);
+    assertEquals(groupMember.getAcceptancePending(), true);
+    assertEquals(groupMember.getInvitedBy(), user);
+    assertEquals(groupMember.getOtpCreationDateTime(), time);
+    assertEquals(groupMember.getMemberFromDateTime(), time);
+  }
+
+  @Test
+  void testGettersSetters() {
+    // given: some known values
+    var uuid = random(UUID.class);
+    var text = random(String.class);
+    var user = random(User.class);
+    var time = OffsetDateTime.now();
+
+    // when: establishing its parameters
+    GroupMember groupMember = random(GroupMember.class);
+    groupMember.setName(text);
+    groupMember.setId(uuid);
+    groupMember.setEmail(text);
+    groupMember.setRegistrationPending(true);
+    groupMember.setAcceptancePending(true);
+    groupMember.setInvitedBy(user);
+    groupMember.setOtpCreationDateTime(time);
+    groupMember.setMemberFromDateTime(time);
+
+    // then: they are correctly recovered
+    assertEquals(groupMember.getId(), uuid);
+    assertEquals(groupMember.getName(), text);
+    assertEquals(groupMember.getEmail(), text);
+    assertEquals(groupMember.getRegistrationPending(), true);
+    assertEquals(groupMember.getAcceptancePending(), true);
+    assertEquals(groupMember.getInvitedBy(), user);
+    assertEquals(groupMember.getOtpCreationDateTime(), time);
+    assertEquals(groupMember.getMemberFromDateTime(), time);
+  }
+
+  @ParameterizedTest(name = "Test getting hash emails: email [{0}]")
+  @ValueSource(strings = {"somebody@email.com", "SOMEBODY@email.com", "somebody@EMAIL.com"})
+  void testGetHash(String email) {
+    // given: a user with email
+    GroupMember groupMember = random(GroupMember.class);
+    groupMember.setEmail(email);
+
+    // when: getting user's hash
+    String hash = groupMember.getHash();
+
+    // then: it should match the provided value
+    assertEquals(hash, "66b0ef1ce525f909ad733d06415331d5");
+  }
+}

--- a/src/test/java/patio/user/services/UserServiceTests.java
+++ b/src/test/java/patio/user/services/UserServiceTests.java
@@ -24,6 +24,8 @@ import static org.hamcrest.Matchers.iterableWithSize;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyListOf;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.List;
 import java.util.Optional;
@@ -82,5 +84,38 @@ public class UserServiceTests {
 
     // then: we should build it
     assertTrue(user.isPresent());
+  }
+
+  @Test
+  void testCreatePendingUsersExistingEmail() {
+    // given: an existing user
+    var user = random(User.class);
+
+    // and: a mocked user repository
+    var userRepository = Mockito.mock(UserRepository.class);
+    Mockito.when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));
+
+    // when: invoking service listUsers()
+    var userService = new DefaultUserService(userRepository);
+    userService.createPendingUsers(List.of(user.getEmail()));
+
+    // then: we should expect the correct number of calls
+    verify(userRepository, times(1)).findByEmail(any());
+    verify(userRepository, times(0)).save(any());
+  }
+
+  @Test
+  void testCreatePendingUsersNewEmail() {
+    // given: a mocked user repository
+    var userRepository = Mockito.mock(UserRepository.class);
+    Mockito.when(userRepository.findByEmail(any())).thenReturn(Optional.empty());
+
+    // when: invoking service listUsers()
+    var userService = new DefaultUserService(userRepository);
+    userService.createPendingUsers(List.of(random(String.class)));
+
+    // then: we should expect the correct number of calls
+    verify(userRepository, times(1)).findByEmail(any());
+    verify(userRepository, times(1)).save(any());
   }
 }

--- a/src/test/java/patio/voting/services/internal/VotingSchedulingServiceTests.java
+++ b/src/test/java/patio/voting/services/internal/VotingSchedulingServiceTests.java
@@ -60,6 +60,8 @@ public class VotingSchedulingServiceTests {
 
     // and: mocking behaviors
     var group1Users = randomSetOf(2, UserGroup.class);
+    group1Users.stream().forEach(u -> u.setAcceptancePending(false));
+
     var group1 =
         Group.builder().with(g -> g.setName("eligible")).with(g -> g.setUsers(group1Users)).build();
     var closedVotingGroups = randomListOf(4, Group.class);

--- a/src/test/resources/patio/group/repositories/testInvitationOtpToGroup.sql
+++ b/src/test/resources/patio/group/repositories/testInvitationOtpToGroup.sql
@@ -1,0 +1,39 @@
+--
+-- Copyright (C) 2019 Kaleidos Open Source SL
+--
+-- This file is part of PATIO.
+-- PATIO is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- PATIO is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+--
+
+-- Avengers
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Avengers', true, time with time zone '00:00:00.146512+01:00', '{"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"}', 24);
+INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea6','Sue Storm', 'sstorm@email.com', 'password', '');
+INSERT INTO users (id, name, email, password, otp) VALUES ('c2a771bc-f8c5-4112-a440-c80fa4c8e382','Ben Grim', 'bgrim@email.com', 'password', '');
+INSERT INTO users (id, name, email, password, otp) VALUES ('84d48a35-7659-4710-ad13-4c47785a0e9d','Johnny Storm', 'jstorm@email.com', 'password', '');
+INSERT INTO users (id, name, email, password, otp) VALUES ('1998c588-d93b-4db6-92e2-a9dbb4cf03b5','Steve Rogers', 'srogers@email.com', 'password', '');
+INSERT INTO users (id, name, email, password, otp) VALUES ('3465094c-5545-4007-a7bc-da2b1a88d9dc','Tony Stark', 'tstark@email.com', 'password', '');
+INSERT INTO users (id, name, email, password, otp) VALUES ('3465094c-5545-4007-a7bc-da2b1a88d9dd', null, 'newUser@email.com', null, null);
+-- Avengers's members
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea6', 't');
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','c2a771bc-f8c5-4112-a440-c80fa4c8e382', 'f');
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','1998c588-d93b-4db6-92e2-a9dbb4cf03b5', 'f');
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','84d48a35-7659-4710-ad13-4c47785a0e9d', 'f');
+-- invited users to join the Avengers
+INSERT INTO users_groups (group_id, user_id, is_acceptance_pending, invitation_otp, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','3465094c-5545-4007-a7bc-da2b1a88d9dc', 't', '$1Otp/a2b1a88d9d1', 'f');
+INSERT INTO users_groups (group_id, user_id, is_acceptance_pending, invitation_otp, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','3465094c-5545-4007-a7bc-da2b1a88d9dd', 't', '$2Otp/a2b1a88d9d2', 'f');
+
+-- Another Team
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('dd4db962-3455-11e9-b210-d663bd873d94','Another Team', true, time with time zone '00:00:00.146512+01:00', '{"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"}', 24);
+INSERT INTO users (id, name, email, password, otp) VALUES ('1118c588-d93b-4db6-92e2-a9dbb4cf0111','hero', 'hero@email.com', 'password', '');
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('dd4db962-3455-11e9-b210-d663bd873d94','1118c588-d93b-4db6-92e2-a9dbb4cf0111', 'f');

--- a/src/test/resources/patio/group/repositories/testUninvitedToGroup.sql
+++ b/src/test/resources/patio/group/repositories/testUninvitedToGroup.sql
@@ -1,0 +1,41 @@
+--
+-- Copyright (C) 2019 Kaleidos Open Source SL
+--
+-- This file is part of PATIO.
+-- PATIO is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- PATIO is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+--
+
+-- Avengers
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Avengers', true, time with time zone '00:00:00.146512+01:00', '{"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"}', 24);
+INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea6','Sue Storm', 'sstorm@email.com', 'password', '');
+INSERT INTO users (id, name, email, password, otp) VALUES ('c2a771bc-f8c5-4112-a440-c80fa4c8e382','Ben Grim', 'bgrim@email.com', 'password', '');
+INSERT INTO users (id, name, email, password, otp) VALUES ('84d48a35-7659-4710-ad13-4c47785a0e9d','Johnny Storm', 'jstorm@email.com', 'password', '');
+INSERT INTO users (id, name, email, password, otp) VALUES ('1998c588-d93b-4db6-92e2-a9dbb4cf03b5','Steve Rogers', 'srogers@email.com', 'password', '');
+INSERT INTO users (id, name, email, password, otp) VALUES ('3465094c-5545-4007-a7bc-da2b1a88d9dc','Tony Stark', 'tstark@email.com', 'password', '');
+INSERT INTO users (id, name, email, password, otp) VALUES ('3465094c-5545-4007-a7bc-da2b1a88d9dd', null, 'newUse1r@email.com', null, null);
+INSERT INTO users (id, name, email, password, otp) VALUES ('a5764857-ae35-34dc-8f25-a9c9e73aa898', null, 'newUser2@email.com', null, null);
+-- Avengers's members
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea6', 't');
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','c2a771bc-f8c5-4112-a440-c80fa4c8e382', 'f');
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','1998c588-d93b-4db6-92e2-a9dbb4cf03b5', 'f');
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','84d48a35-7659-4710-ad13-4c47785a0e9d', 'f');
+-- invited and uninvited users to join the Avengers
+INSERT INTO users_groups (group_id, user_id, is_acceptance_pending, invitation_otp, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','3465094c-5545-4007-a7bc-da2b1a88d9dc', 't', '$1Otp/a2b1a88d9d1', 'f');
+INSERT INTO users_groups (group_id, user_id, is_acceptance_pending, invitation_otp, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','3465094c-5545-4007-a7bc-da2b1a88d9dd', 't', '', 'f');
+INSERT INTO users_groups (group_id, user_id, is_acceptance_pending, invitation_otp, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','a5764857-ae35-34dc-8f25-a9c9e73aa898', 't', null , 'f');
+
+-- Another Team
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('dd4db962-3455-11e9-b210-d663bd873d94','Another Team', true, time with time zone '00:00:00.146512+01:00', '{"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"}', 24);
+INSERT INTO users (id, name, email, password, otp) VALUES ('1118c588-d93b-4db6-92e2-a9dbb4cf0111','hero', 'hero@email.com', 'password', '');
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('dd4db962-3455-11e9-b210-d663bd873d94','1118c588-d93b-4db6-92e2-a9dbb4cf0111', 'f');

--- a/src/test/resources/patio/user/repositories/testFindUsersInvitedToGroup.sql
+++ b/src/test/resources/patio/user/repositories/testFindUsersInvitedToGroup.sql
@@ -1,0 +1,39 @@
+--
+-- Copyright (C) 2019 Kaleidos Open Source SL
+--
+-- This file is part of PATIO.
+-- PATIO is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- PATIO is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with PATIO.  If not, see <https://www.gnu.org/licenses/>
+--
+
+-- Avengers
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','Avengers', true, time with time zone '00:00:00.146512+01:00', '{"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"}', 24);
+INSERT INTO users (id, name, email, password, otp) VALUES ('486590a3-fcc1-4657-a9ed-5f0f95dadea6','Sue Storm', 'sstorm@email.com', 'password', '');
+INSERT INTO users (id, name, email, password, otp) VALUES ('c2a771bc-f8c5-4112-a440-c80fa4c8e382','Ben Grim', 'bgrim@email.com', 'password', '');
+INSERT INTO users (id, name, email, password, otp) VALUES ('84d48a35-7659-4710-ad13-4c47785a0e9d','Johnny Storm', 'jstorm@email.com', 'password', '');
+INSERT INTO users (id, name, email, password, otp) VALUES ('1998c588-d93b-4db6-92e2-a9dbb4cf03b5','Steve Rogers', 'srogers@email.com', 'password', '');
+INSERT INTO users (id, name, email, password, otp) VALUES ('3465094c-5545-4007-a7bc-da2b1a88d9dc','Tony Stark', 'tstark@email.com', 'password', '');
+INSERT INTO users (id, name, email, password, otp) VALUES ('3465094c-5545-4007-a7bc-da2b1a88d9dd', null, 'newUser@email.com', null, null);
+-- Avengers's members
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','486590a3-fcc1-4657-a9ed-5f0f95dadea6', 't');
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','c2a771bc-f8c5-4112-a440-c80fa4c8e382', 'f');
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','1998c588-d93b-4db6-92e2-a9dbb4cf03b5', 'f');
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','84d48a35-7659-4710-ad13-4c47785a0e9d', 'f');
+-- invited users to join the Avengers
+INSERT INTO users_groups (group_id, user_id, is_acceptance_pending, invitation_otp, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','3465094c-5545-4007-a7bc-da2b1a88d9dc', 't', '$2Otp/a2b1a88d9dc', 'f');
+INSERT INTO users_groups (group_id, user_id, is_acceptance_pending, invitation_otp, is_admin) VALUES ('d64db962-3455-11e9-b210-d663bd873d93','3465094c-5545-4007-a7bc-da2b1a88d9dd', 't', '$2Otp/a2b1a88d9dd', 'f');
+
+-- Another Team
+INSERT INTO groups (id, name, anonymous_vote, voting_time, voting_days, voting_duration) VALUES ('dd4db962-3455-11e9-b210-d663bd873d94','Another Team', true, time with time zone '00:00:00.146512+01:00', '{"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"}', 24);
+INSERT INTO users (id, name, email, password, otp) VALUES ('1118c588-d93b-4db6-92e2-a9dbb4cf0111','hero', 'hero@email.com', 'password', '');
+INSERT INTO users_groups (group_id, user_id, is_admin) VALUES ('dd4db962-3455-11e9-b210-d663bd873d94','1118c588-d93b-4db6-92e2-a9dbb4cf0111', 'f');


### PR DESCRIPTION
**Descripción del caso de uso**

Los administradores de un grupo deben poder invitar a futuros nuevos miembros mediante una lista de correos. 
https://tree.taiga.io/project/pabloruiz-kaleidos-patio/us/6?no-milestone=1

![https://media.giphy.com/media/4YY3ED5rWapOkUbeza/giphy.gif](https://media.giphy.com/media/4YY3ED5rWapOkUbeza/giphy.gif)

Cada cuenta de correo indicada debería recibir una invitación con un enlace válido para aceptar la invitación (COTA), indicando su clave OTP personal y si se trata de un nuevo usuario.

Los usuarios que acepten la invitación desde su correo deberían formar parte del grupo una vez logados en la aplicación.
NOTA: Esta US no cubre el alta de nuevos usuarios en patio. 

Todos los nuevos campos requeridos para la lógica de esta US se incorporan al API para su consumo por front.

La nueva funcionalidad debería ser compatible con front y seguir funcionando correctamente (a pesar de su desfase con respecto a back)

**Descripción de solución**

Se habilita una primera mutation para invitar a participantes, que admite como entrada una lista con los correos de los nuevos miembros. Estos correos pueden referirse a usuarios existentes en la aplicación o que todavía no existan.

Los usuarios que previamente existan en la aplicación podrán, como segundo paso, utilizar una nueva mutation para aceptar finalmente la invitación mediante su clave OTP enviada por correo.

Entre los dos pasos anteriores se introduce una tarea programada (cron) que monitoriza los grupos y notifica por correo a aquellas invitaciones pendientes de envío.

Por tanto, los estados que se manejan serían:

*  Estado 0  `No invitado`:    Sin UserGroup
*  Estado 1 `Invitado, no notificado`:    UserGroup (acceptancePending= true, invitationOtp=null, invitedBy=user)
```graphql
 mutation {
   inviteMembersToGroup(

```
*  Estado 2 `Invitado y notificado`:  UserGroup (acceptancePending= true, invitationOtp=$2a, invitedBy=user)
    * El cron pasa del estado 1 al 2 cuando se ejecuta `InvitationSchedulingService.scheduleInvitations`
*  Estado 3 `Invitación aceptada`:                          UserGroup (acceptancePending= false, invitationOtp=null, invitedBy=user)
```graphql
 mutation {
   acceptInvitationToGroup(
```

Para reflejar qué usuario invita al grupo se introduce el campo `userGroup.invitedBy` y se expone en el api.

También se contempla el caso de volver a re-enviar la invitación para alguien ya invitado (por si pierde su invitación). Para ello, se marca como pendiente y el cron:
* lo detecta como pendiente
* genera una nueva OTP
* actualiza la nueva persona que le invita al grupo
* finalmente le envía el correo

Para ususarios no dados de alta en patio: 
* se darán de alta como usuarios pendientes de registro: `User` (email: newMember@domain, registrationPending = true)
* se darán de alta como miembros pendientes del grupo: `UserGroup` (acceptancePending= true, invitationOtp=null, invitedBy=null)
* no se formaliza su alta definitiva como usuario US https://tree.taiga.io/project/pabloruiz-kaleidos-patio/task/400

**Tests de Validación**

*   Cargar un dump de producción y verificar que se aplican bien las migraciones de bd
*   Las fixtures existentes deben seguir cargando y pudiéndose borrar (load/clean)
*   Establecer un correo válido en bbdd donde recibir las invitaciones
*   Habilitar el envío de correos en application.yml
*   Estando logado como usuario admin de un grupo, invitar a al anterior usuario por su email

```
mutation {
   inviteMembersToGroup(
     emailList: ["daniel.herrero@kaleidos.net"], 
   	groupId: "d5847624-4b50-4d4a-abd3-ed9209a5448b"
   )
 }
```

*   Debería recibirse un correo con una OTP válida en el correo indicado

*   Estando logado como el futuro nuevo miembro aceptar la invitación del grupo con la otp recibida por correo

```
mutation {
  acceptInvitationToGroup(otp: "$2a$10$IHRqtYIkqZVFHkIserTEguy90hCcb.WINsT4nb7ZeAz.d75tElkTu" ) {
    name
  }
}
```

*   Repetir la prueba cambiando el locale del application.yml a otro idoma (es/fr/-) (el texto del correo debe cambiar)
*   Repetir la prueba invitando a varios miembros a la vez, con una lista de emails (debería funcionar del mismo modo)
*   Repetir la prueba tratando de invitar a un grupo no siendo administrador del mismo
*   Repetir la prueba tratando de invitar a un grupo que no existe
*   Reiniciar bd y repetir la prueba invitando dos veces al mismo usuario (sin aceptar la invitación), verificando que se recibe el mismo correo con una nueva OTP (caso de pérdida de correo)
*   Repetir la anterior prueba con emails de miembros que ya son del grupo (no debe ocurrir nada)
*   Repetir la anterior prueba con emails de usuarios no existentes en patio
    *   Se deben pre crear los nuevos usuarios pendientes de registro (User)
    *   Se deben pre crear como miembros del grupo con una OTP de invitación válida y marcados como pendientes de aceptación (UserGroup)
* Comprobar que los nuevos campos se exponen en el API (`[GroupMember]` type, accesible desde `[Group].members`
* Comprobar desde el front que la anterio funcionalidad no se ve afectada 
```graphql
 query {
  getGroup(id: "d5847624-4b50-4d4a-abd3-ed9209a5448b") {
    name,
    members {
      id,
      name,
      isAcceptancePending,
      isRegistrationPending,
      otpCreationDateTime,
      memberFromDateTime,
      invitedBy  
    }
  }
}
```

```graphql
query {
  getUser(id: "82b9b72b-1544-4c89-a198-258ca4a5a076") {
    id,
    isRegistrationPending
  }
}
```
